### PR TITLE
Fixes #2

### DIFF
--- a/lua/img-clip/clipboard.lua
+++ b/lua/img-clip/clipboard.lua
@@ -10,16 +10,16 @@ M.get_clip_cmd = function()
       return "powershell.exe"
     end
 
-  -- Linux (X11)
-  elseif os.getenv("DISPLAY") then
-    if util.executable("xclip") then
-      return "xclip"
-    end
-
   -- Linux (Wayland)
   elseif os.getenv("WAYLAND_DISPLAY") then
     if util.executable("wl-paste") then
       return "wl-paste"
+    end
+
+  -- Linux (X11)
+  elseif os.getenv("DISPLAY") then
+    if util.executable("xclip") then
+      return "xclip"
     end
 
   -- MacOS

--- a/tests/clipboard_spec.lua
+++ b/tests/clipboard_spec.lua
@@ -50,7 +50,7 @@ describe("clipboard", function()
   describe("wayland", function()
     before_each(function()
       os.getenv = function(env)
-        return env == "WAYLAND_DISPLAY"
+        return env == "WAYLAND_DISPLAY" or env == "DISPLAY"
       end
       util.has = function()
         return false


### PR DESCRIPTION
This PR fixes #2, where the plugin fails in Wayland sessions due to the `DISPLAY` env variable being set by **XWayland**. This PR makes use of `XDG_SESSION_TYPE` environment variable to check the type of the current session.

I've tested this on **Hyprland**(Wayland) and on **Linux mint**(X11). Works fine on both.