### PR TITLE
feat: embed image as base64

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The plugin comes with the following defaults:
   use_cursor_in_template = true, -- jump to cursor position in template after pasting
   insert_mode_after_paste = true, -- enter insert mode after pasting the markup code
   relative_to_current_file = false, -- make dir_path relative to current file rather than the cwd
-  paste_as_base64 = false, -- paste image as base64 string instead of saving to file
+  embed_as_base64 = false, -- paste image as base64 string instead of saving to file
 
   template = "$FILE_PATH", -- default template
 
@@ -152,7 +152,7 @@ The plugin comes with the following defaults:
 | `use_cursor_in_template`   | `Boolean` | `true`                | Jump to cursor position in template after pasting.                                   |
 | `insert_mode_after_paste`  | `Boolean` | `true`                | Enter insert mode after pasting the markup code.                                     |
 | `relative_to_current_file` | `Boolean` | `false`               | Make `dir_path` relative to current file rather than the cwd.                        |
-| `paste_as_base64`          | `Boolean` | `false`               | Embeds the image as Base64 rather than saving as file. Only supported in Markdown.   |
+| `embed_as_base64`          | `Boolean` | `false`               | Embeds the image as Base64 rather than saving as file. Only supported in Markdown.   |
 | `template`                 | `String`  | `"$FILE_PATH"`        | Default template.                                                                    |
 
 The options can be configured as either static values (e.g. "assets"), or by dynamically generating them through functions. For example, to set the `dir_path` to match the name of the currently opened file:

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The plugin comes with the following defaults:
   use_cursor_in_template = true, -- jump to cursor position in template after pasting
   insert_mode_after_paste = true, -- enter insert mode after pasting the markup code
   relative_to_current_file = false, -- make dir_path relative to current file rather than the cwd
-  embed_image_as_base64 = false, -- paste image as base64 string instead of saving to file
+  embed_image_as_base64 = false, -- embed image as base64 string instead of saving to file
 
   template = "$FILE_PATH", -- default template
 
@@ -152,7 +152,7 @@ The plugin comes with the following defaults:
 | `use_cursor_in_template`   | `Boolean` | `true`                | Jump to cursor position in template after pasting.                                   |
 | `insert_mode_after_paste`  | `Boolean` | `true`                | Enter insert mode after pasting the markup code.                                     |
 | `relative_to_current_file` | `Boolean` | `false`               | Make `dir_path` relative to current file rather than the cwd.                        |
-| `embed_image_as_base64`          | `Boolean` | `false`               | Embeds the image as Base64 rather than saving as file. Only supported in Markdown.   |
+| `embed_image_as_base64`    | `Boolean` | `false`               | Embeds the image as Base64 rather than saving as file. Only supported in Markdown.   |
 | `template`                 | `String`  | `"$FILE_PATH"`        | Default template.                                                                    |
 
 The options can be configured as either static values (e.g. "assets"), or by dynamically generating them through functions. For example, to set the `dir_path` to match the name of the currently opened file:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Paste images directly from your clipboard into any markup language, like LaTeX, 
 ## Features
 
 - **Directly** paste images from the **clipboard**.
+- **Save** images as files or embed them directly as **Base64**.
 - Fully **configurable templates** with cursor placement and figure labels.
 - **Default templates** for widely-used markup languages like LaTeX, Markdown and Typst.
 - **Automatically** generated file names.
@@ -151,7 +152,7 @@ The plugin comes with the following defaults:
 | `use_cursor_in_template`   | `Boolean` | `true`                | Jump to cursor position in template after pasting.                                   |
 | `insert_mode_after_paste`  | `Boolean` | `true`                | Enter insert mode after pasting the markup code.                                     |
 | `relative_to_current_file` | `Boolean` | `false`               | Make `dir_path` relative to current file rather than the cwd.                        |
-| `paste_as_base64`          | `Boolean` | `false`               | Pastes the image as base64 rather than saving as file.                               |
+| `paste_as_base64`          | `Boolean` | `false`               | Embeds the image as Base64 rather than saving as file. Only supported in Markdown.   |
 | `template`                 | `String`  | `"$FILE_PATH"`        | Default template.                                                                    |
 
 The options can be configured as either static values (e.g. "assets"), or by dynamically generating them through functions. For example, to set the `dir_path` to match the name of the currently opened file:

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The plugin comes with the following defaults:
   use_cursor_in_template = true, -- jump to cursor position in template after pasting
   insert_mode_after_paste = true, -- enter insert mode after pasting the markup code
   relative_to_current_file = false, -- make dir_path relative to current file rather than the cwd
-  embed_as_base64 = false, -- paste image as base64 string instead of saving to file
+  embed_image_as_base64 = false, -- paste image as base64 string instead of saving to file
 
   template = "$FILE_PATH", -- default template
 
@@ -152,7 +152,7 @@ The plugin comes with the following defaults:
 | `use_cursor_in_template`   | `Boolean` | `true`                | Jump to cursor position in template after pasting.                                   |
 | `insert_mode_after_paste`  | `Boolean` | `true`                | Enter insert mode after pasting the markup code.                                     |
 | `relative_to_current_file` | `Boolean` | `false`               | Make `dir_path` relative to current file rather than the cwd.                        |
-| `embed_as_base64`          | `Boolean` | `false`               | Embeds the image as Base64 rather than saving as file. Only supported in Markdown.   |
+| `embed_image_as_base64`          | `Boolean` | `false`               | Embeds the image as Base64 rather than saving as file. Only supported in Markdown.   |
 | `template`                 | `String`  | `"$FILE_PATH"`        | Default template.                                                                    |
 
 The options can be configured as either static values (e.g. "assets"), or by dynamically generating them through functions. For example, to set the `dir_path` to match the name of the currently opened file:

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ The plugin comes with the following defaults:
   use_cursor_in_template = true, -- jump to cursor position in template after pasting
   insert_mode_after_paste = true, -- enter insert mode after pasting the markup code
   relative_to_current_file = false, -- make dir_path relative to current file rather than the cwd
+  paste_as_base64 = false, -- paste image as base64 string instead of saving to file
 
   template = "$FILE_PATH", -- default template
 
@@ -143,13 +144,14 @@ The plugin comes with the following defaults:
 | -------------------------- | --------- | --------------------- | ------------------------------------------------------------------------------------ |
 | `dir_path`                 | `String`  | `"assets"`            | Directory path to save images to, can be relative (cwd or current file) or absolute. |
 | `file_name`                | `String`  | `"%Y-%m-%d-%H-%M-%S"` | File name format (see [lua.org/pil/22.1.html](https://www.lua.org/pil/22.1.html)).   |
-| `url_encode_path`          | `Boolean`  | `false`              | Encode spaces and special characters in file path.                                   |
+| `url_encode_path`          | `Boolean` | `false`               | Encode spaces and special characters in file path.                                   |
 | `use_absolute_path`        | `Boolean` | `false`               | Expands `dir_path` to an absolute path.                                              |
 | `prompt_for_file_name`     | `Boolean` | `true`                | Ask user for file name before saving, leave empty to use default.                    |
 | `show_dir_path_in_prompt`  | `Boolean` | `false`               | Show `dir_path` in prompt when prompting for file name.                              |
 | `use_cursor_in_template`   | `Boolean` | `true`                | Jump to cursor position in template after pasting.                                   |
 | `insert_mode_after_paste`  | `Boolean` | `true`                | Enter insert mode after pasting the markup code.                                     |
 | `relative_to_current_file` | `Boolean` | `false`               | Make `dir_path` relative to current file rather than the cwd.                        |
+| `paste_as_base64`          | `Boolean` | `false`               | Pastes the image as base64 rather than saving as file.                               |
 | `template`                 | `String`  | `"$FILE_PATH"`        | Default template.                                                                    |
 
 The options can be configured as either static values (e.g. "assets"), or by dynamically generating them through functions. For example, to set the `dir_path` to match the name of the currently opened file:

--- a/lua/img-clip/clipboard.lua
+++ b/lua/img-clip/clipboard.lua
@@ -10,19 +10,19 @@ M.get_clip_cmd = function()
       return "powershell.exe"
     end
 
-    -- Linux (Wayland)
+  -- Linux (Wayland)
   elseif os.getenv("WAYLAND_DISPLAY") then
     if util.executable("wl-paste") then
       return "wl-paste"
     end
 
-    -- Linux (X11)
+  -- Linux (X11)
   elseif os.getenv("DISPLAY") then
     if util.executable("xclip") then
       return "xclip"
     end
 
-    -- MacOS
+  -- MacOS
   elseif util.has("mac") then
     if util.executable("pngpaste") then
       return "pngpaste"
@@ -42,23 +42,23 @@ M.check_if_content_is_image = function(cmd)
     local output = util.execute("xclip -selection clipboard -t TARGETS -o")
     return output ~= nil and output:find("image/png") ~= nil
 
-    -- Linux (Wayland)
+  -- Linux (Wayland)
   elseif cmd == "wl-paste" then
     local output = util.execute("wl-paste --list-types")
     return output ~= nil and output:find("image/png") ~= nil
 
-    -- MacOS (pngpaste) which is faster than osascript
+  -- MacOS (pngpaste) which is faster than osascript
   elseif cmd == "pngpaste" then
     local _, exit_code = util.execute("pngpaste -")
     return exit_code == 0
 
-    -- MacOS (osascript) as a fallback
-    -- TODO: Add correct quotes aroudn class PNGf
+  -- MacOS (osascript) as a fallback
+  -- TODO: Add correct quotes aroudn class PNGf
   elseif cmd == "osascript" then
     local output = util.execute("osascript -e 'clipboard info'")
     return output ~= nil and output:find("class PNGf") ~= nil
 
-    -- Windows
+  -- Windows
   elseif cmd == "powershell.exe" then
     local output = util.execute("powershell.exe Get-Clipboard -Format Image")
     return output ~= nil and output:find("ImageFormat") ~= nil
@@ -77,30 +77,30 @@ M.save_clipboard_image = function(cmd, file_path)
     local _, exit_code = util.execute(command)
     return exit_code == 0
 
-    -- Linux (Wayland)
+  -- Linux (Wayland)
   elseif cmd == "wl-paste" then
     local command = string.format('wl-paste --type image/png > "%s"', file_path)
     local _, exit_code = util.execute(command)
     return exit_code == 0
 
-    -- MacOS (pngpaste) which is faster than osascript
+  -- MacOS (pngpaste) which is faster than osascript
   elseif cmd == "pngpaste" then
     local command = string.format('pngpaste "%s"', file_path)
     local _, exit_code = util.execute(command)
     return exit_code == 0
 
-    -- MacOS (osascript) as a fallback
+  -- MacOS (osascript) as a fallback
   elseif cmd == "osascript" then
     local command = string.format(
       [[osascript -e 'set theFile to (open for access POSIX file "%s" with write permission)' ]]
-      .. [[-e 'try' -e 'write (the clipboard as «class PNGf») to theFile' -e 'end try' ]]
-      .. [[-e 'close access theFile']],
+        .. [[-e 'try' -e 'write (the clipboard as «class PNGf») to theFile' -e 'end try' ]]
+        .. [[-e 'close access theFile']],
       file_path
     )
     local _, exit_code = util.execute(command)
     return exit_code == 0
 
-    -- Windows
+  -- Windows
   elseif cmd == "powershell.exe" then
     local command = string.format([[powershell.exe "(Get-Clipboard -Format Image).Save('%s')"]], file_path)
     local _, exit_code = util.execute(command)
@@ -118,46 +118,46 @@ M.get_clipboard_image_base64 = function(cmd)
       return output
     end
 
-    -- Linux (Wayland)
+  -- Linux (Wayland)
   elseif cmd == "wl-paste" then
     local output, exit_code = util.execute("wl-paste --type image/png | base64 | tr -d '\n'")
     if exit_code == 0 then
       return output
     end
 
-    -- MacOS (pngpaste)
+  -- MacOS (pngpaste)
   elseif cmd == "pngpaste" then
     local output, exit_code = util.execute("pngpaste - | base64 | tr -d '\n'")
     if exit_code == 0 then
       return output
     end
 
-    -- MacOS (osascript)
+  -- MacOS (osascript)
   elseif cmd == "osascript" then
     local output, exit_code = util.execute(
       [[osascript -e 'set theFile to (open for access POSIX file "/tmp/image.png" with write permission)' ]]
-      .. [[-e 'try' -e 'write (the clipboard as «class PNGf») to theFile' -e 'end try' -e 'close access theFile'; ]]
-      .. [[cat /tmp/image.png | base64 | tr -d "\n" ]]
+        .. [[-e 'try' -e 'write (the clipboard as «class PNGf») to theFile' -e 'end try' -e 'close access theFile'; ]]
+        .. [[cat /tmp/image.png | base64 | tr -d "\n" ]]
     )
     if exit_code == 0 then
       return output
     end
 
-    -- Windows native
+  -- Windows native
   elseif cmd == "powershell.exe" and util.has("win32") then
     local output, exit_code = util.execute(
       [[powershell.exe $ms = New-Object System.IO.MemoryStream; (Get-Clipboard -Format Image)]]
-      .. [[.Save($ms, [System.Drawing.Imaging.ImageFormat]::Png); [System.Convert]::ToBase64String($ms.ToArray())]]
+        .. [[.Save($ms, [System.Drawing.Imaging.ImageFormat]::Png); [System.Convert]::ToBase64String($ms.ToArray())]]
     )
     if exit_code == 0 then
       return output:gsub("\r\n", ""):gsub("\n", ""):gsub("\r", "")
     end
 
-    -- Windows WSL
+  -- Windows WSL
   elseif cmd == "powershell.exe" and util.has("wsl") then
     local output, exit_code = util.execute(
       [[powershell.exe '$ms = New-Object System.IO.MemoryStream; (Get-Clipboard -Format Image)]]
-      .. [[.Save($ms, [System.Drawing.Imaging.ImageFormat]::Png); [System.Convert]::ToBase64String($ms.ToArray())']]
+        .. [[.Save($ms, [System.Drawing.Imaging.ImageFormat]::Png); [System.Convert]::ToBase64String($ms.ToArray())']]
     )
     if exit_code == 0 then
       return output:gsub("\r\n", ""):gsub("\n", ""):gsub("\r", "")

--- a/lua/img-clip/clipboard.lua
+++ b/lua/img-clip/clipboard.lua
@@ -10,19 +10,19 @@ M.get_clip_cmd = function()
       return "powershell.exe"
     end
 
-  -- Linux (Wayland)
+    -- Linux (Wayland)
   elseif os.getenv("WAYLAND_DISPLAY") then
     if util.executable("wl-paste") then
       return "wl-paste"
     end
 
-  -- Linux (X11)
+    -- Linux (X11)
   elseif os.getenv("DISPLAY") then
     if util.executable("xclip") then
       return "xclip"
     end
 
-  -- MacOS
+    -- MacOS
   elseif util.has("mac") then
     if util.executable("pngpaste") then
       return "pngpaste"
@@ -42,25 +42,25 @@ M.check_if_content_is_image = function(cmd)
     local output = util.execute("xclip -selection clipboard -t TARGETS -o")
     return output ~= nil and output:find("image/png") ~= nil
 
-  -- Linux (Wayland)
+    -- Linux (Wayland)
   elseif cmd == "wl-paste" then
     local output = util.execute("wl-paste --list-types")
     return output ~= nil and output:find("image/png") ~= nil
 
-  -- MacOS (pngpaste) which is faster than osascript
+    -- MacOS (pngpaste) which is faster than osascript
   elseif cmd == "pngpaste" then
     local _, exit_code = util.execute("pngpaste -")
     return exit_code == 0
 
-  -- MacOS (osascript) as a fallback
-  -- TODO: Add correct quotes aroudn class PNGf
+    -- MacOS (osascript) as a fallback
+    -- TODO: Add correct quotes aroudn class PNGf
   elseif cmd == "osascript" then
     local output = util.execute("osascript -e 'clipboard info'")
     return output ~= nil and output:find("class PNGf") ~= nil
 
-  -- Windows
+    -- Windows
   elseif cmd == "powershell.exe" then
-    local output = util.execute("powershell.exe -c Get-Clipboard -Format Image")
+    local output = util.execute("powershell.exe Get-Clipboard -Format Image")
     return output ~= nil and output:find("ImageFormat") ~= nil
   end
 
@@ -77,32 +77,32 @@ M.save_clipboard_image = function(cmd, file_path)
     local _, exit_code = util.execute(command)
     return exit_code == 0
 
-  -- Linux (Wayland)
+    -- Linux (Wayland)
   elseif cmd == "wl-paste" then
     local command = string.format('wl-paste --type image/png > "%s"', file_path)
     local _, exit_code = util.execute(command)
     return exit_code == 0
 
-  -- MacOS (pngpaste) which is faster than osascript
+    -- MacOS (pngpaste) which is faster than osascript
   elseif cmd == "pngpaste" then
     local command = string.format('pngpaste "%s"', file_path)
     local _, exit_code = util.execute(command)
     return exit_code == 0
 
-  -- MacOS (osascript) as a fallback
+    -- MacOS (osascript) as a fallback
   elseif cmd == "osascript" then
     local command = string.format(
       [[osascript -e 'set theFile to (open for access POSIX file "%s" with write permission)' ]]
-        .. [[-e 'try' -e 'write (the clipboard as «class PNGf») to theFile' -e 'end try' ]]
-        .. [[-e 'close access theFile']],
+      .. [[-e 'try' -e 'write (the clipboard as «class PNGf») to theFile' -e 'end try' ]]
+      .. [[-e 'close access theFile']],
       file_path
     )
     local _, exit_code = util.execute(command)
     return exit_code == 0
 
-  -- Windows
+    -- Windows
   elseif cmd == "powershell.exe" then
-    local command = string.format([[powershell.exe "(Get-Clipboard -Format Image).save('%s')"]], file_path)
+    local command = string.format([[powershell.exe (Get-Clipboard -Format Image).Save('%s')]], file_path)
     local _, exit_code = util.execute(command)
     return exit_code == 0
   end
@@ -118,39 +118,49 @@ M.get_clipboard_image_base64 = function(cmd)
       return output
     end
 
-  -- Linux (Wayland)
+    -- Linux (Wayland)
   elseif cmd == "wl-paste" then
     local output, exit_code = util.execute("wl-paste --type image/png | base64 | tr -d '\n'")
     if exit_code == 0 then
       return output
     end
 
-  -- MacOS (pngpaste)
+    -- MacOS (pngpaste)
   elseif cmd == "pngpaste" then
     local output, exit_code = util.execute("pngpaste - | base64 | tr -d '\n'")
     if exit_code == 0 then
       return output
     end
 
-  -- MacOS (osascript)
+    -- MacOS (osascript)
   elseif cmd == "osascript" then
     local output, exit_code = util.execute(
       [[osascript -e 'set theFile to (open for access POSIX file "/tmp/image.png" with write permission)' ]]
-        .. [[-e 'try' -e 'write (the clipboard as «class PNGf») to theFile' -e 'end try' -e 'close access theFile'; ]]
-        .. [[cat /tmp/image.png | base64 | tr -d "\n" ]]
+      .. [[-e 'try' -e 'write (the clipboard as «class PNGf») to theFile' -e 'end try' -e 'close access theFile'; ]]
+      .. [[cat /tmp/image.png | base64 | tr -d "\n" ]]
     )
     if exit_code == 0 then
       return output
     end
 
-  -- Windows
-  elseif cmd == "powershell.exe" then
+    -- Windows native
+  elseif cmd == "powershell.exe" and util.has("win32") then
     local output, exit_code = util.execute(
-      [[powershell.exe -command "[System.Convert]::ToBase64String([System.IO.MemoryStream]]
-        .. [[::new((Get-Clipboard -Format Image).Bmp).ToArray()) | ForEach-Object {$_ -replace '`n',''}"]]
+      [[powershell.exe $ms = New-Object System.IO.MemoryStream; (Get-Clipboard -Format Image)]]
+      .. [[.Save($ms, [System.Drawing.Imaging.ImageFormat]::Png); [System.Convert]::ToBase64String($ms.ToArray())]]
     )
     if exit_code == 0 then
-      return output
+      return output:gsub("\n", "")
+    end
+
+    -- Windows WSL
+  elseif cmd == "powershell.exe" and util.has("wsl") then
+    local output, exit_code = util.execute(
+      [[powershell.exe '$ms = New-Object System.IO.MemoryStream; (Get-Clipboard -Format Image)]]
+      .. [[.Save($ms, [System.Drawing.Imaging.ImageFormat]::Png); [System.Convert]::ToBase64String($ms.ToArray())']]
+    )
+    if exit_code == 0 then
+      return output:gsub("\n", "")
     end
   end
 

--- a/lua/img-clip/clipboard.lua
+++ b/lua/img-clip/clipboard.lua
@@ -146,7 +146,8 @@ M.get_clipboard_image_base64 = function(cmd)
   -- Windows
   elseif cmd == "powershell.exe" then
     local output, exit_code = util.execute(
-      [[powershell.exe -command "[System.Convert]::ToBase64String([System.IO.MemoryStream]::new((Get-Clipboard -Format Image).Bmp).ToArray()) | ForEach-Object {$_ -replace '`n',''}"]]
+      [[powershell.exe -command "[System.Convert]::ToBase64String([System.IO.MemoryStream]]
+        .. [[::new((Get-Clipboard -Format Image).Bmp).ToArray()) | ForEach-Object {$_ -replace '`n',''}"]]
     )
     if exit_code == 0 then
       return output

--- a/lua/img-clip/clipboard.lua
+++ b/lua/img-clip/clipboard.lua
@@ -131,6 +131,16 @@ M.get_clipboard_image_base64 = function(cmd)
     if exit_code == 0 then
       return output
     end
+
+  -- MacOS (osascript)
+  elseif cmd == "osascript" then
+    local output, exit_code = util.execute(
+      [[osascript -e 'set content to the clipboard as «class PNGf»' ]]
+        .. [[-e 'do shell script "echo " & content | base64 | tr -d "\n"' ]]
+    )
+    if exit_code == 0 then
+      return output
+    end
   end
 
   return nil

--- a/lua/img-clip/clipboard.lua
+++ b/lua/img-clip/clipboard.lua
@@ -135,8 +135,9 @@ M.get_clipboard_image_base64 = function(cmd)
   -- MacOS (osascript)
   elseif cmd == "osascript" then
     local output, exit_code = util.execute(
-      [[osascript -e 'set content to the clipboard as «class PNGf»' ]]
-        .. [[-e 'do shell script "echo " & content | base64 | tr -d "\n"' ]]
+      [[osascript -e 'set theFile to (open for access POSIX file "/tmp/image.png" with write permission)' ]]
+        .. [[-e 'try' -e 'write (the clipboard as «class PNGf») to theFile' -e 'end try' -e 'close access theFile'; ]]
+        .. [[cat /tmp/image.png | base64 | tr -d "\n" ]]
     )
     if exit_code == 0 then
       return output

--- a/lua/img-clip/clipboard.lua
+++ b/lua/img-clip/clipboard.lua
@@ -110,4 +110,15 @@ M.save_clipboard_image = function(cmd, file_path)
   return false
 end
 
+M.get_clipboard_image_base64 = function(cmd)
+  if cmd == "xclip" then
+    local output, exit_code = util.execute("xclip -selection clipboard -o -t image/png | base64 | tr -d '\n'")
+    if exit_code == 0 then
+      return output
+    end
+  end
+
+  return nil
+end
+
 return M

--- a/lua/img-clip/clipboard.lua
+++ b/lua/img-clip/clipboard.lua
@@ -150,7 +150,7 @@ M.get_clipboard_image_base64 = function(cmd)
       .. [[.Save($ms, [System.Drawing.Imaging.ImageFormat]::Png); [System.Convert]::ToBase64String($ms.ToArray())]]
     )
     if exit_code == 0 then
-      return output:gsub("\n", "")
+      return output:gsub("\r\n", ""):gsub("\n", ""):gsub("\r", "")
     end
 
     -- Windows WSL
@@ -160,7 +160,7 @@ M.get_clipboard_image_base64 = function(cmd)
       .. [[.Save($ms, [System.Drawing.Imaging.ImageFormat]::Png); [System.Convert]::ToBase64String($ms.ToArray())']]
     )
     if exit_code == 0 then
-      return output:gsub("\n", "")
+      return output:gsub("\r\n", ""):gsub("\n", ""):gsub("\r", "")
     end
   end
 

--- a/lua/img-clip/clipboard.lua
+++ b/lua/img-clip/clipboard.lua
@@ -111,8 +111,16 @@ M.save_clipboard_image = function(cmd, file_path)
 end
 
 M.get_clipboard_image_base64 = function(cmd)
+  -- Linux (X11)
   if cmd == "xclip" then
     local output, exit_code = util.execute("xclip -selection clipboard -o -t image/png | base64 | tr -d '\n'")
+    if exit_code == 0 then
+      return output
+    end
+
+  -- Linux (Wayland)
+  elseif cmd == "wl-paste" then
+    local output, exit_code = util.execute("wl-paste --type image/png | base64 | tr -d '\n'")
     if exit_code == 0 then
       return output
     end

--- a/lua/img-clip/clipboard.lua
+++ b/lua/img-clip/clipboard.lua
@@ -124,6 +124,13 @@ M.get_clipboard_image_base64 = function(cmd)
     if exit_code == 0 then
       return output
     end
+
+  -- MacOS (pngpaste)
+  elseif cmd == "pngpaste" then
+    local output, exit_code = util.execute("pngpaste - | base64 | tr -d '\n'")
+    if exit_code == 0 then
+      return output
+    end
   end
 
   return nil

--- a/lua/img-clip/clipboard.lua
+++ b/lua/img-clip/clipboard.lua
@@ -141,6 +141,15 @@ M.get_clipboard_image_base64 = function(cmd)
     if exit_code == 0 then
       return output
     end
+
+  -- Windows
+  elseif cmd == "powershell.exe" then
+    local output, exit_code = util.execute(
+      [[powershell.exe -command "[System.Convert]::ToBase64String([System.IO.MemoryStream]::new((Get-Clipboard -Format Image).Bmp).ToArray()) | ForEach-Object {$_ -replace '`n',''}"]]
+    )
+    if exit_code == 0 then
+      return output
+    end
   end
 
   return nil

--- a/lua/img-clip/clipboard.lua
+++ b/lua/img-clip/clipboard.lua
@@ -102,7 +102,7 @@ M.save_clipboard_image = function(cmd, file_path)
 
     -- Windows
   elseif cmd == "powershell.exe" then
-    local command = string.format([[powershell.exe (Get-Clipboard -Format Image).Save('%s')]], file_path)
+    local command = string.format([[powershell.exe "(Get-Clipboard -Format Image).Save('%s')"]], file_path)
     local _, exit_code = util.execute(command)
     return exit_code == 0
   end

--- a/lua/img-clip/config.lua
+++ b/lua/img-clip/config.lua
@@ -10,7 +10,7 @@ local defaults = {
   use_cursor_in_template = true, -- jump to cursor position in template after pasting
   insert_mode_after_paste = true, -- enter insert mode after pasting the markup code
   relative_to_current_file = false, -- make dir_path relative to current file rather than the cwd
-  embed_as_base64 = false, -- paste image as base64 string instead of saving to file
+  embed_image_as_base64 = false, -- paste image as base64 string instead of saving to file
 
   template = "$FILE_PATH",
 

--- a/lua/img-clip/config.lua
+++ b/lua/img-clip/config.lua
@@ -10,7 +10,7 @@ local defaults = {
   use_cursor_in_template = true, -- jump to cursor position in template after pasting
   insert_mode_after_paste = true, -- enter insert mode after pasting the markup code
   relative_to_current_file = false, -- make dir_path relative to current file rather than the cwd
-  paste_as_base64 = false, -- paste image as base64 string instead of saving to file
+  embed_as_base64 = false, -- paste image as base64 string instead of saving to file
 
   template = "$FILE_PATH",
 

--- a/lua/img-clip/config.lua
+++ b/lua/img-clip/config.lua
@@ -10,6 +10,7 @@ local defaults = {
   use_cursor_in_template = true, -- jump to cursor position in template after pasting
   insert_mode_after_paste = true, -- enter insert mode after pasting the markup code
   relative_to_current_file = false, -- make dir_path relative to current file rather than the cwd
+  paste_as_base64 = false, -- paste image as base64 string instead of saving to file
 
   template = "$FILE_PATH",
 

--- a/lua/img-clip/init.lua
+++ b/lua/img-clip/init.lua
@@ -31,9 +31,9 @@ M.pasteImage = function(opts)
   end
 
   -- paste as base 64
-  if config.get_option("paste_as_base64", opts) then
+  if config.get_option("embed_as_base64", opts) then
     if M._language_supports_base64_embedding(vim.bo.filetype) then
-      return M._paste_as_base64(opts)
+      return M._embed_as_base64(opts)
     else
       util.warn("Base64 is not supported in this filetype. Pasting as file instead.")
     end
@@ -85,7 +85,7 @@ end
 
 ---@param opts? table
 ---@return boolean
-M._paste_as_base64 = function(opts)
+M._embed_as_base64 = function(opts)
   -- get the base64 string
   local base64 = clipboard.get_clipboard_image_base64(clip_cmd)
   if not base64 then

--- a/lua/img-clip/init.lua
+++ b/lua/img-clip/init.lua
@@ -30,6 +30,23 @@ M.pasteImage = function(opts)
     return false
   end
 
+  -- paste as base 64
+  if config.get_option("paste_as_base64", opts) then
+    if M._language_supports_base64(vim.bo.filetype) then
+      return M._paste_as_base64(opts)
+    else
+      util.warn("Base64 is not supported in this filetype. Pasting as file instead.")
+    end
+  end
+
+  return M._paste_as_file(opts)
+end
+
+M._language_supports_base64 = function(ft)
+  return ft == "markdown" or ft == "rmd"
+end
+
+M._paste_as_file = function(opts)
   -- get the file path
   local file_path = fs.get_file_path("png", opts)
   if not file_path then
@@ -60,6 +77,34 @@ M.pasteImage = function(opts)
   end
 
   return true
+end
+
+M._paste_as_base64 = function(opts)
+  -- get the base64 string
+  local base64 = clipboard.get_clipboard_image_base64(clip_cmd)
+  if not base64 then
+    util.error("Could not get base64 string.")
+    return false
+  end
+
+  local prefix = M._get_base64_prefix(vim.bo.filetype)
+
+  -- get the markup for the image
+  local markup_ok = markup.insert_markup(prefix .. base64, opts)
+  if not markup_ok then
+    util.error("Could not insert markup code.")
+    return false
+  end
+
+  return true
+end
+
+M._get_base64_prefix = function(ft)
+  if ft == "markdown" or ft == "rmd" then
+    return "data:image/png;base64,"
+  end
+
+  return ""
 end
 
 return M

--- a/lua/img-clip/init.lua
+++ b/lua/img-clip/init.lua
@@ -31,9 +31,9 @@ M.pasteImage = function(opts)
   end
 
   -- paste as base 64
-  if config.get_option("embed_as_base64", opts) then
+  if config.get_option("embed_image_as_base64", opts) then
     if M._language_supports_base64_embedding(vim.bo.filetype) then
-      return M._embed_as_base64(opts)
+      return M._embed_image_as_base64(opts)
     else
       util.warn("Base64 is not supported in this filetype. Pasting as file instead.")
     end
@@ -85,7 +85,7 @@ end
 
 ---@param opts? table
 ---@return boolean
-M._embed_as_base64 = function(opts)
+M._embed_image_as_base64 = function(opts)
   -- get the base64 string
   local base64 = clipboard.get_clipboard_image_base64(clip_cmd)
   if not base64 then

--- a/lua/img-clip/init.lua
+++ b/lua/img-clip/init.lua
@@ -32,7 +32,7 @@ M.pasteImage = function(opts)
 
   -- paste as base 64
   if config.get_option("paste_as_base64", opts) then
-    if M._language_supports_base64(vim.bo.filetype) then
+    if M._language_supports_base64_embedding(vim.bo.filetype) then
       return M._paste_as_base64(opts)
     else
       util.warn("Base64 is not supported in this filetype. Pasting as file instead.")
@@ -42,10 +42,14 @@ M.pasteImage = function(opts)
   return M._paste_as_file(opts)
 end
 
-M._language_supports_base64 = function(ft)
+---@param ft string
+---@return boolean
+M._language_supports_base64_embedding = function(ft)
   return ft == "markdown" or ft == "rmd"
 end
 
+---@param opts? table
+---@return boolean
 M._paste_as_file = function(opts)
   -- get the file path
   local file_path = fs.get_file_path("png", opts)
@@ -79,6 +83,8 @@ M._paste_as_file = function(opts)
   return true
 end
 
+---@param opts? table
+---@return boolean
 M._paste_as_base64 = function(opts)
   -- get the base64 string
   local base64 = clipboard.get_clipboard_image_base64(clip_cmd)
@@ -99,6 +105,8 @@ M._paste_as_base64 = function(opts)
   return true
 end
 
+---@param ft string
+---@return string
 M._get_base64_prefix = function(ft)
   if ft == "markdown" or ft == "rmd" then
     return "data:image/png;base64,"

--- a/lua/img-clip/markup.lua
+++ b/lua/img-clip/markup.lua
@@ -56,30 +56,28 @@ M.url_encode = function(str)
   return str
 end
 
----@param file_path string
+---@param file string the file path or base64 string
 ---@param opts? table
 ---@return boolean
-function M.insert_markup(file_path, opts)
+function M.insert_markup(file, opts)
   local template = config.get_option("template", opts)
   if not template then
     return false
   end
 
-  local file_name = vim.fn.fnamemodify(file_path, ":t")
-  local file_name_no_ext = vim.fn.fnamemodify(file_path, ":t:r")
+  local file_name = vim.fn.fnamemodify(file, ":t")
+  local file_name_no_ext = vim.fn.fnamemodify(file, ":t:r")
   local label = file_name_no_ext:gsub("%s+", "-"):lower()
 
   -- url encode path
   if config.get_option("url_encode_path", opts) then
-    file_path = M.url_encode(file_path)
-    file_path = file_path:gsub("%%", "%%%%") -- escape % so we can call gsub again
+    file = M.url_encode(file)
+    file = file:gsub("%%", "%%%%") -- escape % so we can call gsub again
   end
-
-  print(file_path)
 
   template = template:gsub("$FILE_NAME_NO_EXT", file_name_no_ext)
   template = template:gsub("$FILE_NAME", file_name)
-  template = template:gsub("$FILE_PATH", file_path)
+  template = template:gsub("$FILE_PATH", file)
   template = template:gsub("$LABEL", label)
 
   if not config.get_option("use_cursor_in_template", opts) then

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -13,7 +13,7 @@ describe("config", function()
     assert.is_false(config.get_option("use_absolute_path"))
     assert.is_true(config.get_option("insert_mode_after_paste"))
     assert.is_true(config.get_option("use_cursor_in_template"))
-    assert.is_false(config.get_option("embed_as_base64"))
+    assert.is_false(config.get_option("embed_image_as_base64"))
     assert.equals("$FILE_PATH", config.get_option("template"))
   end)
 

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -13,7 +13,7 @@ describe("config", function()
     assert.is_false(config.get_option("use_absolute_path"))
     assert.is_true(config.get_option("insert_mode_after_paste"))
     assert.is_true(config.get_option("use_cursor_in_template"))
-    assert.is_false(config.get_option("paste_as_base64"))
+    assert.is_false(config.get_option("embed_as_base64"))
     assert.equals("$FILE_PATH", config.get_option("template"))
   end)
 

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -13,6 +13,7 @@ describe("config", function()
     assert.is_false(config.get_option("use_absolute_path"))
     assert.is_true(config.get_option("insert_mode_after_paste"))
     assert.is_true(config.get_option("use_cursor_in_template"))
+    assert.is_false(config.get_option("paste_as_base64"))
     assert.equals("$FILE_PATH", config.get_option("template"))
   end)
 

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -97,8 +97,8 @@ describe("img-clip.init", function()
       assert.spy(util.error).was_called_with("Could not insert markup code.")
     end)
 
-    it("pastes as base64 when embed_as_base64 is true and filetype supports base64", function()
-      local opts = { embed_as_base64 = true }
+    it("pastes as base64 when embed_image_as_base64 is true and filetype supports base64", function()
+      local opts = { embed_image_as_base64 = true }
       vim.bo.filetype = "markdown"
 
       clipboard.get_clipboard_image_base64 = function()
@@ -109,8 +109,8 @@ describe("img-clip.init", function()
       assert.is_true(success)
     end)
 
-    it("pastes as file when embed_as_base64 is true but filetype does not support base64", function()
-      local opts = { embed_as_base64 = true }
+    it("pastes as file when embed_image_as_base64 is true but filetype does not support base64", function()
+      local opts = { embed_image_as_base64 = true }
       vim.bo.filetype = "txt"
 
       local success = init.pasteImage(opts)
@@ -118,8 +118,8 @@ describe("img-clip.init", function()
       assert.spy(util.warn).was_called_with("Base64 is not supported in this filetype. Pasting as file instead.")
     end)
 
-    it("pastes as file when embed_as_base64 is false", function()
-      local opts = { embed_as_base64 = false }
+    it("pastes as file when embed_image_as_base64 is false", function()
+      local opts = { embed_image_as_base64 = false }
       vim.bo.filetype = "markdown"
 
       local success = init.pasteImage(opts)
@@ -127,7 +127,7 @@ describe("img-clip.init", function()
     end)
 
     it("errors if base64 encoding fails", function()
-      local opts = { embed_as_base64 = true }
+      local opts = { embed_image_as_base64 = true }
       vim.bo.filetype = "markdown"
 
       clipboard.get_clipboard_image_base64 = function()
@@ -140,7 +140,7 @@ describe("img-clip.init", function()
     end)
 
     it("errors if base64 markup cannot be inserted", function()
-      local opts = { embed_as_base64 = true }
+      local opts = { embed_image_as_base64 = true }
       vim.bo.filetype = "markdown"
 
       clipboard.get_clipboard_image_base64 = function()

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -97,8 +97,8 @@ describe("img-clip.init", function()
       assert.spy(util.error).was_called_with("Could not insert markup code.")
     end)
 
-    it("pastes as base64 when paste_as_base64 is true and filetype supports base64", function()
-      local opts = { paste_as_base64 = true }
+    it("pastes as base64 when embed_as_base64 is true and filetype supports base64", function()
+      local opts = { embed_as_base64 = true }
       vim.bo.filetype = "markdown"
 
       clipboard.get_clipboard_image_base64 = function()
@@ -109,8 +109,8 @@ describe("img-clip.init", function()
       assert.is_true(success)
     end)
 
-    it("pastes as file when paste_as_base64 is true but filetype does not support base64", function()
-      local opts = { paste_as_base64 = true }
+    it("pastes as file when embed_as_base64 is true but filetype does not support base64", function()
+      local opts = { embed_as_base64 = true }
       vim.bo.filetype = "txt"
 
       local success = init.pasteImage(opts)
@@ -118,8 +118,8 @@ describe("img-clip.init", function()
       assert.spy(util.warn).was_called_with("Base64 is not supported in this filetype. Pasting as file instead.")
     end)
 
-    it("pastes as file when paste_as_base64 is false", function()
-      local opts = { paste_as_base64 = false }
+    it("pastes as file when embed_as_base64 is false", function()
+      local opts = { embed_as_base64 = false }
       vim.bo.filetype = "markdown"
 
       local success = init.pasteImage(opts)
@@ -127,7 +127,7 @@ describe("img-clip.init", function()
     end)
 
     it("errors if base64 encoding fails", function()
-      local opts = { paste_as_base64 = true }
+      local opts = { embed_as_base64 = true }
       vim.bo.filetype = "markdown"
 
       clipboard.get_clipboard_image_base64 = function()
@@ -140,7 +140,7 @@ describe("img-clip.init", function()
     end)
 
     it("errors if base64 markup cannot be inserted", function()
-      local opts = { paste_as_base64 = true }
+      local opts = { embed_as_base64 = true }
       vim.bo.filetype = "markdown"
 
       clipboard.get_clipboard_image_base64 = function()


### PR DESCRIPTION
## Summary of changes

Embeds image as Base64 rather than saving the file and referencing it in the markup. Only works for Markdown currently, as LaTeX and Typst do not support embedding images as Base64.