### PR TITLE
feat: base64 limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The plugin comes with the following defaults:
   insert_mode_after_paste = true, -- enter insert mode after pasting the markup code
   relative_to_current_file = false, -- make dir_path relative to current file rather than the cwd
   embed_image_as_base64 = false, -- embed image as base64 string instead of saving to file
+  max_base64_size = 15, -- max size of base64 string in KB
 
   template = "$FILE_PATH", -- default template
 
@@ -153,6 +154,7 @@ The plugin comes with the following defaults:
 | `insert_mode_after_paste`  | `Boolean` | `true`                | Enter insert mode after pasting the markup code.                                     |
 | `relative_to_current_file` | `Boolean` | `false`               | Make `dir_path` relative to current file rather than the cwd.                        |
 | `embed_image_as_base64`    | `Boolean` | `false`               | Embeds the image as Base64 rather than saving as file. Only supported in Markdown.   |
+| `max_base64_size`          | `Integer` | `15`                  | Max size of Base64 string in KB. Pastes as file if Base64 string is too large.       |
 | `template`                 | `String`  | `"$FILE_PATH"`        | Default template.                                                                    |
 
 The options can be configured as either static values (e.g. "assets"), or by dynamically generating them through functions. For example, to set the `dir_path` to match the name of the currently opened file:

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The plugin comes with the following defaults:
   insert_mode_after_paste = true, -- enter insert mode after pasting the markup code
   relative_to_current_file = false, -- make dir_path relative to current file rather than the cwd
   embed_image_as_base64 = false, -- embed image as base64 string instead of saving to file
-  max_base64_size = 15, -- max size of base64 string in KB
+  max_base64_size = 10, -- max size of base64 string in KB
 
   template = "$FILE_PATH", -- default template
 
@@ -154,7 +154,7 @@ The plugin comes with the following defaults:
 | `insert_mode_after_paste`  | `Boolean` | `true`                | Enter insert mode after pasting the markup code.                                     |
 | `relative_to_current_file` | `Boolean` | `false`               | Make `dir_path` relative to current file rather than the cwd.                        |
 | `embed_image_as_base64`    | `Boolean` | `false`               | Embeds the image as Base64 rather than saving as file. Only supported in Markdown.   |
-| `max_base64_size`          | `Integer` | `15`                  | Max size of Base64 string in KB. Pastes as file if Base64 string is too large.       |
+| `max_base64_size`          | `Integer` | `10`                  | Max size of Base64 string in KB. Pastes as file if Base64 string is too large.       |
 | `template`                 | `String`  | `"$FILE_PATH"`        | Default template.                                                                    |
 
 The options can be configured as either static values (e.g. "assets"), or by dynamically generating them through functions. For example, to set the `dir_path` to match the name of the currently opened file:

--- a/lua/img-clip/config.lua
+++ b/lua/img-clip/config.lua
@@ -11,7 +11,7 @@ local defaults = {
   insert_mode_after_paste = true, -- enter insert mode after pasting the markup code
   relative_to_current_file = false, -- make dir_path relative to current file rather than the cwd
   embed_image_as_base64 = false, -- paste image as base64 string instead of saving to file
-  max_base64_size = 15, -- max size of base64 string in KB
+  max_base64_size = 10, -- max size of base64 string in KB
 
   template = "$FILE_PATH",
 

--- a/lua/img-clip/config.lua
+++ b/lua/img-clip/config.lua
@@ -11,6 +11,7 @@ local defaults = {
   insert_mode_after_paste = true, -- enter insert mode after pasting the markup code
   relative_to_current_file = false, -- make dir_path relative to current file rather than the cwd
   embed_image_as_base64 = false, -- paste image as base64 string instead of saving to file
+  max_base64_size = 15, -- max size of base64 string in KB
 
   template = "$FILE_PATH",
 

--- a/lua/img-clip/init.lua
+++ b/lua/img-clip/init.lua
@@ -30,12 +30,10 @@ M.pasteImage = function(opts)
     return false
   end
 
-  -- paste as base 64
-  if config.get_option("embed_image_as_base64", opts) then
-    if M._language_supports_base64_embedding(vim.bo.filetype) then
-      return M._embed_image_as_base64(opts)
-    else
-      util.warn("Base64 is not supported in this filetype. Pasting as file instead.")
+  -- paste as base 64 if enabled and supported, otherwise paste as file
+  if config.get_option("embed_image_as_base64", opts) and M._language_supports_base64_embedding(vim.bo.filetype) then
+    if M._embed_image_as_base64(opts) then
+      return true
     end
   end
 
@@ -90,6 +88,11 @@ M._embed_image_as_base64 = function(opts)
   local base64 = clipboard.get_clipboard_image_base64(clip_cmd)
   if not base64 then
     util.error("Could not get base64 string.")
+    return false
+  end
+
+  -- check if base64 string is too long - max_base64_size is in KB
+  if string.len(base64) > config.get_option("max_base64_size", opts) * 1024 then
     return false
   end
 

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -14,6 +14,7 @@ describe("config", function()
     assert.is_true(config.get_option("insert_mode_after_paste"))
     assert.is_true(config.get_option("use_cursor_in_template"))
     assert.is_false(config.get_option("embed_image_as_base64"))
+    assert.equal(15, config.get_option("max_base64_size"))
     assert.equals("$FILE_PATH", config.get_option("template"))
   end)
 

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -14,7 +14,7 @@ describe("config", function()
     assert.is_true(config.get_option("insert_mode_after_paste"))
     assert.is_true(config.get_option("use_cursor_in_template"))
     assert.is_false(config.get_option("embed_image_as_base64"))
-    assert.equal(15, config.get_option("max_base64_size"))
+    assert.equal(10, config.get_option("max_base64_size"))
     assert.equals("$FILE_PATH", config.get_option("template"))
   end)
 


### PR DESCRIPTION
## Related issue

Closes #9.

## Summary of changes

Added a `max_base64_size` option which defines the max size of the Base64 string in KB. Keep in mind embedding as Base64 will increase the file size with 33%, and 10KB of Base64 equals 10 240 characters.
