### PR TITLE
fix: clipboard not working on windows

### DIFF
--- a/lua/img-clip/clipboard.lua
+++ b/lua/img-clip/clipboard.lua
@@ -95,13 +95,24 @@ M.save_clipboard_image = function(cmd, file_path)
     local _, exit_code = util.execute(command)
     return exit_code == 0
 
-    -- Windows
-  elseif cmd == "powershell.exe" then
+    -- Windows (native)
+  elseif cmd == "powershell.exe" and util.has("win32") then
     local command = string.format([[
     powershell.exe "Add-Type -AssemblyName System.Windows.Forms;
     Add-Type -AssemblyName System.Drawing;
     $img = [System.Windows.Forms.Clipboard]::GetImage();
     $img.Save('%s', [System.Drawing.Imaging.ImageFormat]::Png);"
+  ]], file_path)
+    local _, exit_code = util.execute(command)
+    return exit_code == 0
+
+    -- Windows (WSL)
+  elseif cmd == "powershell.exe" and util.has("wsl") then
+    local command = string.format([[
+    powershell.exe 'Add-Type -AssemblyName System.Windows.Forms;
+    Add-Type -AssemblyName System.Drawing;
+    $img = [System.Windows.Forms.Clipboard]::GetImage();
+    $img.Save("%s", [System.Drawing.Imaging.ImageFormat]::Png);'
   ]], file_path)
     local _, exit_code = util.execute(command)
     return exit_code == 0
@@ -143,7 +154,7 @@ M.get_clipboard_image_base64 = function(cmd)
       return output
     end
 
-    -- Windows native
+    -- Windows (native)
   elseif cmd == "powershell.exe" and util.has("win32") then
     local output, exit_code = util.execute(
       [[powershell.exe $ms = New-Object System.IO.MemoryStream; (Get-Clipboard -Format Image)]]
@@ -153,7 +164,7 @@ M.get_clipboard_image_base64 = function(cmd)
       return output:gsub("\r\n", ""):gsub("\n", ""):gsub("\r", "")
     end
 
-    -- Windows WSL
+    -- Windows (WSL)
   elseif cmd == "powershell.exe" and util.has("wsl") then
     local output, exit_code = util.execute(
       [[powershell.exe '$ms = New-Object System.IO.MemoryStream; (Get-Clipboard -Format Image)]]

--- a/lua/img-clip/clipboard.lua
+++ b/lua/img-clip/clipboard.lua
@@ -157,8 +157,9 @@ M.get_clipboard_image_base64 = function(cmd)
     -- Windows (native)
   elseif cmd == "powershell.exe" and util.has("win32") then
     local output, exit_code = util.execute(
-      [[powershell.exe $ms = New-Object System.IO.MemoryStream; (Get-Clipboard -Format Image)]]
-      .. [[.Save($ms, [System.Drawing.Imaging.ImageFormat]::Png); [System.Convert]::ToBase64String($ms.ToArray())]]
+      [[powershell.exe "Add-Type -AssemblyName System.Windows.Forms; $ms = New-Object System.IO.MemoryStream;]]
+      .. [[ [System.Windows.Forms.Clipboard]::GetImage().Save($ms, [System.Drawing.Imaging.ImageFormat]::Png);]]
+      .. [[ [System.Convert]::ToBase64String($ms.ToArray())"]]
     )
     if exit_code == 0 then
       return output:gsub("\r\n", ""):gsub("\n", ""):gsub("\r", "")
@@ -167,8 +168,9 @@ M.get_clipboard_image_base64 = function(cmd)
     -- Windows (WSL)
   elseif cmd == "powershell.exe" and util.has("wsl") then
     local output, exit_code = util.execute(
-      [[powershell.exe '$ms = New-Object System.IO.MemoryStream; (Get-Clipboard -Format Image)]]
-      .. [[.Save($ms, [System.Drawing.Imaging.ImageFormat]::Png); [System.Convert]::ToBase64String($ms.ToArray())']]
+      [[powershell.exe 'Add-Type -AssemblyName System.Windows.Forms; $ms = New-Object System.IO.MemoryStream;]]
+      .. [[ [System.Windows.Forms.Clipboard]::GetImage().Save($ms, [System.Drawing.Imaging.ImageFormat]::Png);]]
+      .. [[ [System.Convert]::ToBase64String($ms.ToArray())']]
     )
     if exit_code == 0 then
       return output:gsub("\r\n", ""):gsub("\n", ""):gsub("\r", "")

--- a/lua/img-clip/clipboard.lua
+++ b/lua/img-clip/clipboard.lua
@@ -8,15 +8,15 @@ M.get_clip_cmd = function()
   if (util.has("win32") or util.has("wsl")) and util.executable("powershell.exe") then
     return "powershell.exe"
 
-    -- Linux (Wayland)
+  -- Linux (Wayland)
   elseif os.getenv("WAYLAND_DISPLAY") and util.executable("wl-paste") then
     return "wl-paste"
 
-    -- Linux (X11)
+  -- Linux (X11)
   elseif os.getenv("DISPLAY") and util.executable("xclip") then
     return "xclip"
 
-    -- MacOS
+  -- MacOS
   elseif util.has("mac") then
     if util.executable("pngpaste") then
       return "pngpaste"
@@ -36,23 +36,23 @@ M.check_if_content_is_image = function(cmd)
     local output = util.execute("xclip -selection clipboard -t TARGETS -o")
     return output ~= nil and output:find("image/png") ~= nil
 
-    -- Linux (Wayland)
+  -- Linux (Wayland)
   elseif cmd == "wl-paste" then
     local output = util.execute("wl-paste --list-types")
     return output ~= nil and output:find("image/png") ~= nil
 
-    -- MacOS (pngpaste) which is faster than osascript
+  -- MacOS (pngpaste) which is faster than osascript
   elseif cmd == "pngpaste" then
     local _, exit_code = util.execute("pngpaste -")
     return exit_code == 0
 
-    -- MacOS (osascript) as a fallback
-    -- TODO: Add correct quotes aroudn class PNGf
+  -- MacOS (osascript) as a fallback
+  -- TODO: Add correct quotes aroudn class PNGf
   elseif cmd == "osascript" then
     local output = util.execute("osascript -e 'clipboard info'")
     return output ~= nil and output:find("class PNGf") ~= nil
 
-    -- Windows
+  -- Windows
   elseif cmd == "powershell.exe" then
     local output =
       util.execute("Add-Type -AssemblyName System.Windows.Forms; [System.Windows.Forms.Clipboard]::GetImage()", true)
@@ -72,19 +72,19 @@ M.save_clipboard_image = function(cmd, file_path)
     local _, exit_code = util.execute(command)
     return exit_code == 0
 
-    -- Linux (Wayland)
+  -- Linux (Wayland)
   elseif cmd == "wl-paste" then
     local command = string.format('wl-paste --type image/png > "%s"', file_path)
     local _, exit_code = util.execute(command)
     return exit_code == 0
 
-    -- MacOS (pngpaste) which is faster than osascript
+  -- MacOS (pngpaste) which is faster than osascript
   elseif cmd == "pngpaste" then
     local command = string.format('pngpaste "%s"', file_path)
     local _, exit_code = util.execute(command)
     return exit_code == 0
 
-    -- MacOS (osascript) as a fallback
+  -- MacOS (osascript) as a fallback
   elseif cmd == "osascript" then
     local command = string.format(
       [[osascript -e 'set theFile to (open for access POSIX file "%s" with write permission)' ]]
@@ -95,7 +95,7 @@ M.save_clipboard_image = function(cmd, file_path)
     local _, exit_code = util.execute(command)
     return exit_code == 0
 
-    -- Windows
+  -- Windows
   elseif cmd == "powershell.exe" then
     local command = string.format(
       "Add-Type -AssemblyName System.Windows.Forms; [System.Windows.Forms.Clipboard]::GetImage().Save('%s')",
@@ -116,21 +116,21 @@ M.get_clipboard_image_base64 = function(cmd)
       return output
     end
 
-    -- Linux (Wayland)
+  -- Linux (Wayland)
   elseif cmd == "wl-paste" then
     local output, exit_code = util.execute("wl-paste --type image/png | base64 | tr -d '\n'")
     if exit_code == 0 then
       return output
     end
 
-    -- MacOS (pngpaste)
+  -- MacOS (pngpaste)
   elseif cmd == "pngpaste" then
     local output, exit_code = util.execute("pngpaste - | base64 | tr -d '\n'")
     if exit_code == 0 then
       return output
     end
 
-    -- MacOS (osascript)
+  -- MacOS (osascript)
   elseif cmd == "osascript" then
     local output, exit_code = util.execute(
       [[osascript -e 'set theFile to (open for access POSIX file "/tmp/image.png" with write permission)' ]]
@@ -141,7 +141,7 @@ M.get_clipboard_image_base64 = function(cmd)
       return output
     end
 
-    -- Windows
+  -- Windows
   elseif cmd == "powershell.exe" then
     local output, exit_code = util.execute(
       [[Add-Type -AssemblyName System.Windows.Forms; $ms = New-Object System.IO.MemoryStream;]]

--- a/lua/img-clip/clipboard.lua
+++ b/lua/img-clip/clipboard.lua
@@ -56,7 +56,7 @@ M.check_if_content_is_image = function(cmd)
   elseif cmd == "powershell.exe" then
     local output =
       util.execute("Add-Type -AssemblyName System.Windows.Forms; [System.Windows.Forms.Clipboard]::GetImage()", true)
-    return output ~= nil and output:find("ImageFormat") ~= nil
+    return output ~= nil and output:find("Width") ~= nil
   end
 
   return false

--- a/lua/img-clip/config.lua
+++ b/lua/img-clip/config.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 local defaults = {
+  debug = false,
   dir_path = "assets", -- directory path to save images to, can be relative (cwd or current file) or absolute
   file_name = "%Y-%m-%d-%H-%M-%S", -- file name format (see lua.org/pil/22.1.html)
   url_encode_path = false, -- encode spaces and special characters in file path

--- a/tests/clipboard_spec.lua
+++ b/tests/clipboard_spec.lua
@@ -202,8 +202,7 @@ describe("clipboard", function()
 
     -- TODO: Get correct output of powershell
     it("returns true if clipboard content is an image", function()
-      util.execute = function(command)
-        assert(command:match("powershell.exe"))
+      util.execute = function()
         return "ImageFormat", 0 -- output of powershell
       end
 
@@ -212,8 +211,7 @@ describe("clipboard", function()
 
     -- TODO: Get correct output of powershell
     it("returns false if clipboard content is not an image", function()
-      util.execute = function(command)
-        assert(command:match("powershell.exe"))
+      util.execute = function()
         return "", 0 -- output of powershell
       end
 
@@ -221,8 +219,7 @@ describe("clipboard", function()
     end)
 
     it("successfully saves an image", function()
-      util.execute = function(command)
-        assert(command:match("powershell.exe"))
+      util.execute = function()
         return nil, 0 -- simulate successful execution
       end
 

--- a/tests/clipboard_spec.lua
+++ b/tests/clipboard_spec.lua
@@ -200,16 +200,31 @@ describe("clipboard", function()
       assert.equals("powershell.exe", clipboard.get_clip_cmd())
     end)
 
-    -- TODO: Get correct output of powershell
     it("returns true if clipboard content is an image", function()
+      -- pwsh output, see issue https://github.com/HakonHarnes/img-clip.nvim/issues/13
       util.execute = function()
-        return "ImageFormat", 0 -- output of powershell
+        return [[
+�[32;1mTag                  : �[0m
+�[32;1mPhysicalDimension    : �[0m{Width=93, Height=189}
+�[32;1mSize                 : �[0m{Width=93, Height=189}
+�[32;1mWidth                : �[0m93
+�[32;1mHeight               : �[0m189
+�[32;1mHorizontalResolution : �[0m96
+�[32;1mVerticalResolution   : �[0m96
+�[32;1mFlags                : �[0m335888
+�[32;1mRawFormat            : �[0mMemoryBMP
+�[32;1mPixelFormat          : �[0mFormat32bppRgb
+�[32;1mPropertyIdList       : �[0m{}
+�[32;1mPropertyItems        : �[0m{}
+�[32;1mPalette              : �[0mSystem.Drawing.Imaging.ColorPalette
+�[32;1mFrameDimensionsList  : �[0m{7462dc86-6180-4c7e-8e3f-ee7333a7a483}
+]],
+          0
       end
 
       assert.is_true(clipboard.check_if_content_is_image("powershell.exe"))
     end)
 
-    -- TODO: Get correct output of powershell
     it("returns false if clipboard content is not an image", function()
       util.execute = function()
         return "", 0 -- output of powershell

--- a/tests/util_spec.lua
+++ b/tests/util_spec.lua
@@ -1,0 +1,79 @@
+local util = require("img-clip.util")
+
+describe("util", function()
+  describe("_is_image_url", function()
+    it("should return true for valid urls", function()
+      assert.is_true(util.is_image_url("https://example.com/image.png"))
+      assert.is_true(util.is_image_url("http://example.com/image.png"))
+      assert.is_true(util.is_image_url("https://example.com/image.jpg"))
+      assert.is_true(util.is_image_url("http://example.com/image.jpg"))
+      assert.is_true(util.is_image_url("https://example.com/image.jpeg"))
+      assert.is_true(util.is_image_url("http://example.com/image.jpeg"))
+    end)
+  end)
+
+  describe("execute", function()
+    before_each(function()
+      vim.o.shell = "cmd.exe"
+      vim.fn.system = function(cmd)
+        return cmd
+      end
+
+      vim.fn.has = function()
+        return 0
+      end
+    end)
+
+    it("should return output and exit code", function()
+      local command = "command"
+      local output, exit_code = util.execute(command)
+
+      assert.equal(output, command)
+      assert.equal(exit_code, 0)
+    end)
+
+    it("should execute .NET commands directly if shell is powershell", function()
+      vim.o.shell = "powershell"
+
+      local command = "command"
+      local output, exit_code = util.execute(command, true)
+
+      assert.equal(command, output)
+      assert.equal(exit_code, 0)
+    end)
+
+    it("should execute .NET commands directly if shell is pwsh", function()
+      vim.o.shell = "pwsh"
+
+      local command = "command"
+      local output, exit_code = util.execute(command, true)
+
+      assert.equal(command, output)
+      assert.equal(exit_code, 0)
+    end)
+
+    it("should wrap the command in powershell.exe -Command if shell is cmd.exe", function()
+      local command = 'command "path/to/file"'
+      local output, exit_code = util.execute(command, true)
+
+      assert.equal([[powershell.exe -Command "command 'path/to/file'"]], output)
+      assert.equal(exit_code, 0)
+    end)
+
+    it("should wrap the command in powershell.exe -Command if in WSL", function()
+      vim.fn.has = function(feature)
+        if feature == "wsl" then
+          return 1
+        else
+          return 0
+        end
+      end
+
+      local command = "command 'path/to/file'"
+      local output, exit_code = util.execute(command, true)
+
+      assert.equal([[powershell.exe -Command 'command "path/to/file"']], output)
+      assert.equal(exit_code, 0)
+    end)
+  end)
+end)

--- a/tests/util_spec.lua
+++ b/tests/util_spec.lua
@@ -1,17 +1,6 @@
 local util = require("img-clip.util")
 
 describe("util", function()
-  describe("_is_image_url", function()
-    it("should return true for valid urls", function()
-      assert.is_true(util.is_image_url("https://example.com/image.png"))
-      assert.is_true(util.is_image_url("http://example.com/image.png"))
-      assert.is_true(util.is_image_url("https://example.com/image.jpg"))
-      assert.is_true(util.is_image_url("http://example.com/image.jpg"))
-      assert.is_true(util.is_image_url("https://example.com/image.jpeg"))
-      assert.is_true(util.is_image_url("http://example.com/image.jpeg"))
-    end)
-  end)
-
   describe("execute", function()
     before_each(function()
       vim.o.shell = "cmd.exe"


### PR DESCRIPTION
## Related issue

Closes #13.

Issue occured because `Get-Clipboard -Format Image` does not work in some Powershell versions, see: 

```
Get-Clipboard : A parameter cannot be found that matches parameter name 'Format'
```

Another issue was the default shell used in Neovim was changed from the default `cmd.exe` to `pwsh` (obtained from `:set shell?`), which caused parsing issues when attempting to get the clipboard. 

## Summary of changes

- Replaced the `Get-Clipboard` command to equivalent `.NET` command. 
- Format the powershell commands correctly by handled different `shell` values.

The Powershell commands are handled as follows: 
1. If the `shell` is `powershell` or `pwsh`, then execute the command directly. 
2. If the client uses WSL, wrap the command in `powershell.exe -Command 'command "path/to/file.png"'`
3. Otherwise (including the default `cmd.exe`), wrap the command in `powershell.exe -Command "command 'path/to/file'"`

Notice the difference between single and double quotes in the above commands, which ensures correct parsing of the commands in the different shell environments. 