### PR TITLE
fix: wsl drag and drop

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,11 +372,9 @@ A list of terminal emulators and their capabilities is given below.
   </tbody>
 </table>
 
-> 💡 If you're having issues on Windows, change the shell to `powershell` or `pwsh`. See `:h shell-powershell`.
+> 💡 If you're having issues on Windows, try changing the default shell to `powershell` or `pwsh`. See `:h shell-powershell`.
 
 > ⚠️ MacOS URLs only work in Safari.
-
-> ⚠️ WSL is currently not supported.
 
 ## Demonstration
 

--- a/lua/img-clip/drag_and_drop.lua
+++ b/lua/img-clip/drag_and_drop.lua
@@ -90,23 +90,15 @@ end
 ---@return string
 local function sanitize_input(str)
   str = str:match("^%s*(.-)%s*$") -- remove leading and trailing whitespace
-  str = str:match('^"?(.-)"?$') -- remove double quotes
-  str = str:match("^'?(.-)'?$") -- remove single quotes
-  str = str:gsub("file://", "") -- remove "file://"
+  str = str:match('^"?(.-)"?$')   -- remove double quotes
+  str = str:match("^'?(.-)'?$")   -- remove single quotes
+  str = str:gsub("file://", "")   -- remove "file://"
   return str
 end
 
 ---@param input string
 ---@return boolean status
 M.handle_paste = function(input)
-  if config.get_option("drag_and_drop.enabled") == false then
-    return false
-  end
-
-  if config.get_option("drag_and_drop.insert_mode") == false and vim.fn.mode() == "i" then
-    return false
-  end
-
   input = sanitize_input(input)
 
   if util.is_image_url(input) then

--- a/lua/img-clip/drag_and_drop.lua
+++ b/lua/img-clip/drag_and_drop.lua
@@ -90,9 +90,9 @@ end
 ---@return string
 local function sanitize_input(str)
   str = str:match("^%s*(.-)%s*$") -- remove leading and trailing whitespace
-  str = str:match('^"?(.-)"?$')   -- remove double quotes
-  str = str:match("^'?(.-)'?$")   -- remove single quotes
-  str = str:gsub("file://", "")   -- remove "file://"
+  str = str:match('^"?(.-)"?$') -- remove double quotes
+  str = str:match("^'?(.-)'?$") -- remove single quotes
+  str = str:gsub("file://", "") -- remove "file://"
   return str
 end
 

--- a/plugin/img-clip.lua
+++ b/plugin/img-clip.lua
@@ -32,16 +32,24 @@ end
 -- it will contain the path to the image or file, or a link to the image
 vim.paste = (function(overridden)
   return function(lines, phase)
+    if config.get_option("drag_and_drop.enabled") == false then
+      return overridden(lines, phase)
+    end
+
+    if config.get_option("drag_and_drop.insert_mode") == false and vim.fn.mode() == "i" then
+      return overridden(lines, phase)
+    end
+
+    if #lines > 2 or #lines == 0 then
+      return overridden(lines, phase)
+    end
+
     if phase ~= -1 then
       return convert_streaming_paste(lines, phase)
     end
 
     if config.get_option("debug") then
       print("Paste: " .. vim.inspect(lines))
-    end
-
-    if #lines > 2 or #lines == 0 then
-      return overridden(lines, phase)
     end
 
     local line = lines[1]
@@ -51,11 +59,7 @@ vim.paste = (function(overridden)
       return overridden(lines, phase)
     end
 
-    if config.get_option("debug") then
-      print("Line: " .. line)
-    end
-
-    if not drag_and_drop.handle_paste(lines[1]) then
+    if not drag_and_drop.handle_paste(line) then
       if config.get_option("debug") then
         print("Did not handle paste, calling original vim.paste")
       end

--- a/plugin/img-clip.lua
+++ b/plugin/img-clip.lua
@@ -32,6 +32,10 @@ end
 -- it will contain the path to the image or file, or a link to the image
 vim.paste = (function(overridden)
   return function(lines, phase)
+    if config.get_option("debug") then
+      print("Paste: " .. vim.inspect(lines))
+    end
+
     if config.get_option("drag_and_drop.enabled") == false then
       return overridden(lines, phase)
     end
@@ -40,19 +44,20 @@ vim.paste = (function(overridden)
       return overridden(lines, phase)
     end
 
-    if #lines > 2 or #lines == 0 then
-      return overridden(lines, phase)
-    end
-
     if phase ~= -1 then
       return convert_streaming_paste(lines, phase)
     end
 
-    if config.get_option("debug") then
-      print("Paste: " .. vim.inspect(lines))
+    if #lines > 2 or #lines == 0 then
+      return overridden(lines, phase)
     end
 
+
     local line = lines[1]
+
+    if config.get_option("debug") then
+      print("Line: " .. line)
+    end
 
     -- probably not a file path or url to an image if the input is this long
     if string.len(line) > 512 then

--- a/plugin/img-clip.lua
+++ b/plugin/img-clip.lua
@@ -20,7 +20,7 @@ local function convert_streaming_paste(lines, phase)
     end
   end
 
-  if phase == 3 then              -- end of the paste  if phase == 3 then              -- end of the paste
+  if phase == 3 then              -- end of the paste
     local complete_lines = vim.split(buffer, "\n")
     vim.paste(complete_lines, -1) -- use -1 to indicate non-streaming paste
   end

--- a/plugin/img-clip.lua
+++ b/plugin/img-clip.lua
@@ -20,7 +20,7 @@ local function convert_streaming_paste(lines, phase)
     end
   end
 
-  if phase == 3 then              -- end of the paste
+  if phase == 3 then -- end of the paste
     local complete_lines = vim.split(buffer, "\n")
     vim.paste(complete_lines, -1) -- use -1 to indicate non-streaming paste
   end
@@ -51,7 +51,6 @@ vim.paste = (function(overridden)
     if #lines > 2 or #lines == 0 then
       return overridden(lines, phase)
     end
-
 
     local line = lines[1]
 

--- a/tests/drag_and_drop_spec.lua
+++ b/tests/drag_and_drop_spec.lua
@@ -12,25 +12,6 @@ describe("drag and drop", function()
       end
     end)
 
-    it("should return false drag and drop is not enabled", function()
-      config.setup({ default = {
-        drag_and_drop = {
-          enabled = false,
-        },
-      } })
-
-      local result = drag_and_drop.handle_paste("path/to/image.png")
-      assert.is_false(result)
-    end)
-
-    it("should return false in insert mode", function()
-      vim.fn.mode = function()
-        return "i"
-      end
-      local result = drag_and_drop.handle_paste("path/to/image.png")
-      assert.is_false(result)
-    end)
-
     it("should return false if input is not url or path", function()
       local result = drag_and_drop.handle_paste("some string")
       assert.is_false(result)

--- a/vimdoc.md
+++ b/vimdoc.md
@@ -222,8 +222,6 @@ A list of terminal emulators and their capabilities is given below.
 | [Cmder](https://github.com/cmderdev/cmder)                         |   N/A    |   N/A   |   N/A    |   N/A   |   N/A    |   N/A   |    No    |   No    |
 | [ConEmu](https://github.com/Maximus5/ConEmu)                       |   N/A    |   N/A   |   N/A    |   N/A   |   N/A    |   N/A   |    No    |   No    |
 
-_\*If you're having issues on Windows, change the shell to `powershell` or `pwsh`. See `:h shell-powershell`._
+_\*If you're having issues on Windows, try changing the default shell to `powershell` or `pwsh`. See `:h shell-powershell`._
 
 _\*MacOS URLs only work in Safari._
-
-_\*WSL is currently not supported._


### PR DESCRIPTION
## Summary of changes

Converts streaming pastes to non-streaming pastes, which caused multiple `vim.paste` calls in WSL. Also moved some of the checks to `plugin/img-clip.lua` to only do this conversion when it's really necessary. 
