### PR TITLE
fix: relative to current file markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The plugin comes with the following defaults:
     url_encode_path = false, -- encode spaces and special characters in file path
     use_absolute_path = false, -- expands dir_path to an absolute path
     relative_to_current_file = false, -- make dir_path relative to current file rather than the cwd
+    relative_template_path = true, -- make file path in the template relative to current file rather than the cwd
     prompt_for_file_name = true, -- ask user for file name before saving, leave empty to use default
     show_dir_path_in_prompt = false, -- show dir_path in prompt when prompting for file name
     use_cursor_in_template = true, -- jump to cursor position in template after pasting
@@ -113,6 +114,7 @@ The plugin comes with the following defaults:
   },
 
   tex = {
+    relative_template_path = false,
     template = [[
 \begin{figure}[h]
   \centering

--- a/lua/img-clip/config.lua
+++ b/lua/img-clip/config.lua
@@ -8,6 +8,7 @@ local defaults = {
     url_encode_path = false, -- encode spaces and special characters in file path
     use_absolute_path = false, -- expands dir_path to an absolute path
     relative_to_current_file = false, -- make dir_path relative to current file rather than the cwd
+    relative_template_path = true, -- make file path in the template relative to current file rather than the cwd
     prompt_for_file_name = true, -- ask user for file name before saving, leave empty to use default
     show_dir_path_in_prompt = false, -- show dir_path in prompt when prompting for file name
     use_cursor_in_template = true, -- jump to cursor position in template after pasting
@@ -44,6 +45,7 @@ local defaults = {
   },
 
   tex = {
+    relative_template_path = false,
     template = [[
 \begin{figure}[h]
   \centering
@@ -88,6 +90,7 @@ local defaults = {
 
 defaults.plaintex = defaults.tex
 defaults.rmd = defaults.markdown
+defaults.md = defaults.markdown
 
 M.options = {}
 

--- a/lua/img-clip/fs.lua
+++ b/lua/img-clip/fs.lua
@@ -12,6 +12,17 @@ M.normalize_path = function(path)
   return vim.fn.simplify(path):gsub(M.sep .. "$", "") .. M.sep
 end
 
+---@param file_path string
+---@return string
+M.relative_to_current_file = function(file_path)
+  local current_file_path = vim.fn.expand("%:.:h")
+  if current_file_path ~= "." and current_file_path ~= "" then
+    file_path = file_path:gsub("^" .. current_file_path, "")
+    file_path = file_path:gsub("^" .. M.sep, "")
+  end
+  return file_path
+end
+
 ---@param str string
 ---@param ext string
 ---@return string

--- a/lua/img-clip/fs.lua
+++ b/lua/img-clip/fs.lua
@@ -16,7 +16,7 @@ end
 ---@return string[]
 local function split_path(str)
   local result = {}
-  local pattern = "[^" .. M.sep .. "]+"
+  local pattern = "[^/\\]+"
 
   for part in string.gmatch(str, pattern) do
     table.insert(result, part)

--- a/lua/img-clip/markup.lua
+++ b/lua/img-clip/markup.lua
@@ -71,9 +71,13 @@ function M.insert_markup(file_path, opts)
   local label = file_name_no_ext:gsub("%s+", "-"):lower()
 
   -- see issue #21
-  local ft = vim.bo.filetype
-  if ft == "markdown" or ft == "md" then
-    file_path = fs.relative_to_current_file(file_path)
+  local current_dir_path = vim.fn.expand("%:p:h")
+  print(current_dir_path)
+  if current_dir_path ~= vim.fn.getcwd() then
+    local ft = vim.bo.filetype
+    if ft == "markdown" or ft == "md" or ft == "rmd" or ft == "wiki" or ft == "vimwiki" then
+      file_path = fs.relpath(file_path, current_dir_path)
+    end
   end
 
   -- url encode path

--- a/lua/img-clip/markup.lua
+++ b/lua/img-clip/markup.lua
@@ -74,7 +74,7 @@ function M.insert_markup(file_path, opts)
   local current_dir_path = vim.fn.expand("%:p:h")
   if current_dir_path ~= vim.fn.getcwd() and not config.get_option("use_absolute_path") then
     local ft = vim.bo.filetype
-    if ft == "markdown" or ft == "md" or ft == "rmd" or ft == "wiki" or ft == "vimwiki" then
+    if ft ~= "tex" and ft ~= "plaintex" then
       file_path = fs.relpath(file_path, current_dir_path)
     end
   end

--- a/lua/img-clip/markup.lua
+++ b/lua/img-clip/markup.lua
@@ -72,7 +72,6 @@ function M.insert_markup(file_path, opts)
 
   -- see issue #21
   local current_dir_path = vim.fn.expand("%:p:h")
-  print(current_dir_path)
   if current_dir_path ~= vim.fn.getcwd() then
     local ft = vim.bo.filetype
     if ft == "markdown" or ft == "md" or ft == "rmd" or ft == "wiki" or ft == "vimwiki" then

--- a/lua/img-clip/markup.lua
+++ b/lua/img-clip/markup.lua
@@ -72,7 +72,7 @@ function M.insert_markup(file_path, opts)
 
   -- see issue #21
   local current_dir_path = vim.fn.expand("%:p:h")
-  if current_dir_path ~= vim.fn.getcwd() then
+  if current_dir_path ~= vim.fn.getcwd() and not config.get_option("use_absolute_path") then
     local ft = vim.bo.filetype
     if ft == "markdown" or ft == "md" or ft == "rmd" or ft == "wiki" or ft == "vimwiki" then
       file_path = fs.relpath(file_path, current_dir_path)

--- a/lua/img-clip/markup.lua
+++ b/lua/img-clip/markup.lua
@@ -72,11 +72,12 @@ function M.insert_markup(file_path, opts)
 
   -- see issue #21
   local current_dir_path = vim.fn.expand("%:p:h")
-  if current_dir_path ~= vim.fn.getcwd() and not config.get_option("use_absolute_path") then
-    local ft = vim.bo.filetype
-    if ft ~= "tex" and ft ~= "plaintex" then
-      file_path = fs.relpath(file_path, current_dir_path)
-    end
+  if
+    config.get_option("relative_template_path")
+    and not config.get_option("use_absolute_path")
+    and current_dir_path ~= vim.fn.getcwd()
+  then
+    file_path = fs.relpath(file_path, current_dir_path)
   end
 
   -- url encode path

--- a/tests/fs_spec.lua
+++ b/tests/fs_spec.lua
@@ -215,6 +215,14 @@ describe("fs", function()
       )
     end)
 
+    it("handles a mix of different path separators", function()
+      fs.sep = "\\"
+      assert.equals(
+        "..\\assets\\image.png",
+        fs.relpath("C:\\home\\user\\project\\assets\\image.png", "C:/home/user/project/scripts")
+      )
+    end)
+
     it("handles same directory path correctly", function()
       assert.equals("file.txt", fs.relpath("/home/user/project/scripts/file.txt", "/home/user/project/scripts"))
     end)

--- a/tests/fs_spec.lua
+++ b/tests/fs_spec.lua
@@ -192,4 +192,31 @@ describe("fs", function()
       end)
     end)
   end)
+
+  describe("relpath", function()
+    before_each(function()
+      fs.sep = "/"
+
+      config.setup({}) -- use default config values
+    end)
+
+    it("computes the correct relative path on Linux", function()
+      assert.equals(
+        "../assets/image.png",
+        fs.relpath("/home/user/project/assets/image.png", "/home/user/project/scripts")
+      )
+    end)
+
+    it("computes the correct relative path on Windows", function()
+      fs.sep = "\\"
+      assert.equals(
+        "..\\assets\\image.png",
+        fs.relpath("C:\\home\\user\\project\\assets\\image.png", "C:\\home\\user\\project\\scripts")
+      )
+    end)
+
+    it("handles same directory path correctly", function()
+      assert.equals("file.txt", fs.relpath("/home/user/project/scripts/file.txt", "/home/user/project/scripts"))
+    end)
+  end)
 end)

--- a/vimdoc.md
+++ b/vimdoc.md
@@ -77,6 +77,7 @@ The plugin comes with the following defaults:
     url_encode_path = false, -- encode spaces and special characters in file path
     use_absolute_path = false, -- expands dir_path to an absolute path
     relative_to_current_file = false, -- make dir_path relative to current file rather than the cwd
+    relative_template_path = true, -- make file path in the template relative to current file rather than the cwd
     prompt_for_file_name = true, -- ask user for file name before saving, leave empty to use default
     show_dir_path_in_prompt = false, -- show dir_path in prompt when prompting for file name
     use_cursor_in_template = true, -- jump to cursor position in template after pasting
@@ -113,6 +114,7 @@ The plugin comes with the following defaults:
   },
 
   tex = {
+    relative_template_path = false,
     template = [[
 \begin{figure}[h]
   \centering


### PR DESCRIPTION
## Related issue

Closes #21.

## Summary of changes

- Added the `relpath` function for resolving relative paths. 
- Added the `relative_template_path` option.
- Updated docs to reflect changes.
