### PR TITLE
fix: add -NoProfile to powershell.exe options to speedup

### DIFF
--- a/lua/img-clip/util.lua
+++ b/lua/img-clip/util.lua
@@ -25,12 +25,12 @@ M.execute = function(cmd, powershell)
   -- WSL requires the command to have the format:
   -- powershell.exe -Command 'command "path/to/file"'
   elseif M.has("wsl") then
-    command = "powershell.exe -Command '" .. cmd:gsub("'", '"') .. "'"
+    command = "powershell.exe -NoProfile -Command '" .. cmd:gsub("'", '"') .. "'"
 
   -- cmd.exe requires the command to have the format:
   -- powershell.exe -Command "command 'path/to/file'"
   else
-    command = 'powershell.exe -Command "' .. cmd:gsub('"', "'") .. '"'
+    command = 'powershell.exe -NoProfile -Command "' .. cmd:gsub('"', "'") .. '"'
   end
 
   local output = vim.fn.system(command)


### PR DESCRIPTION
The startup of powershell.exe is unbearably slow without the -NoProfile option. Because we don't need the profiles of powershell.exe, add this option will greatly improve the experience.

## Summary of changes

Add -NoProfile option to powershell.exe
