### PR TITLE
feat: arguments in template function

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,14 @@ Templates in the plugin use placeholders that are dynamically replaced with the 
 | `$LABEL`            | Figure label, generated from the file name, converted to lower-case and with spaces replaced by dashes. | `the-image` (from `the image.png`) |
 | `$CURSOR`           | Indicates where the cursor will be placed after insertion if `use_cursor_in_template` is true.          |                                    |
 
+Templates can also be defined using functions with the above placeholders available as function parameters:
+
+```lua
+template = function(placeholders)
+  return "![" .. placeholders.cursor .. "](" .. placeholders.file_path .. ")"
+end
+```
+
 ## Drag and drop
 
 The drag and drop feature enables users to drag images from the web browser or file explorer into the terminal to automatically embed them, in **normal mode**. For this to work correctly, the following is required by the terminal emulator:

--- a/README.md
+++ b/README.md
@@ -201,8 +201,8 @@ Templates in the plugin use placeholders that are dynamically replaced with the 
 Templates can also be defined using functions with the above placeholders available as function parameters:
 
 ```lua
-template = function(placeholders)
-  return "![" .. placeholders.cursor .. "](" .. placeholders.file_path .. ")"
+template = function(context)
+  return "![" .. context.cursor .. "](" .. context.file_path .. ")"
 end
 ```
 

--- a/lua/img-clip/config.lua
+++ b/lua/img-clip/config.lua
@@ -136,6 +136,18 @@ M.get_option = function(key, opts)
     return nil
   end
 
+  if key == "template" and type(val) == "function" then
+    local placeholders = {
+      file_path = "$FILE_PATH",
+      file_name = "$FILE_NAME",
+      file_name_no_ext = "$FILE_NAME_NO_EXT",
+      cursor = "$CURSOR",
+      label = "$LABEL",
+    }
+
+    return val(placeholders)
+  end
+
   return type(val) == "function" and val() or val -- execute if function
 end
 

--- a/lua/img-clip/config.lua
+++ b/lua/img-clip/config.lua
@@ -97,7 +97,7 @@ M.options = {}
 ---@param key string
 ---@param opts? table The options passed to pasteImage function
 ---@return string | nil
-M.get_option = function(key, opts)
+M.get_option = function(key, opts, args)
   local ft = vim.bo.filetype
   local val
 
@@ -136,19 +136,7 @@ M.get_option = function(key, opts)
     return nil
   end
 
-  if key == "template" and type(val) == "function" then
-    local placeholders = {
-      file_path = "$FILE_PATH",
-      file_name = "$FILE_NAME",
-      file_name_no_ext = "$FILE_NAME_NO_EXT",
-      cursor = "$CURSOR",
-      label = "$LABEL",
-    }
-
-    return val(placeholders)
-  end
-
-  return type(val) == "function" and val() or val -- execute if function
+  return type(val) == "function" and val(args or {}) or val -- execute if function
 end
 
 function M.setup(opts)

--- a/lua/img-clip/markup.lua
+++ b/lua/img-clip/markup.lua
@@ -61,11 +61,6 @@ end
 ---@param opts? table
 ---@return boolean
 function M.insert_markup(file_path, opts)
-  local template = config.get_option("template", opts)
-  if not template then
-    return false
-  end
-
   local file_name = vim.fn.fnamemodify(file_path, ":t")
   local file_name_no_ext = vim.fn.fnamemodify(file_path, ":t:r")
   local label = file_name_no_ext:gsub("%s+", "-"):lower()
@@ -78,6 +73,19 @@ function M.insert_markup(file_path, opts)
     and current_dir_path ~= vim.fn.getcwd()
   then
     file_path = fs.relpath(file_path, current_dir_path)
+  end
+
+  -- pass args to template
+  local template_args = {
+    file_path = file_path,
+    file_name = file_name,
+    file_name_no_ext = file_name_no_ext,
+    cursor = "$CURSOR",
+    label = label,
+  }
+  local template = config.get_option("template", opts, template_args)
+  if not template then
+    return false
   end
 
   -- url encode path

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -42,26 +42,4 @@ describe("config", function()
     local opts = { file_name = "custom-filename" }
     assert.equals("custom-filename", config.get_option("file_name", opts))
   end)
-
-  it("should correctly process a function template with all parameters", function()
-    vim.bo.filetype = "markdown"
-
-    local template_func = function(context)
-      return "File: "
-        .. context.file_name
-        .. ", Path: "
-        .. context.file_path
-        .. ", Cursor: "
-        .. context.cursor
-        .. ", Label: "
-        .. context.label
-        .. ", No Ext: "
-        .. context.file_name_no_ext
-    end
-
-    config.setup({ markdown = { template = template_func } })
-
-    local expected = "File: $FILE_NAME, Path: $FILE_PATH, Cursor: $CURSOR, Label: $LABEL, No Ext: $FILE_NAME_NO_EXT"
-    assert.equals(expected, config.get_option("template"))
-  end)
 end)

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -42,4 +42,26 @@ describe("config", function()
     local opts = { file_name = "custom-filename" }
     assert.equals("custom-filename", config.get_option("file_name", opts))
   end)
+
+  it("should correctly process a function template with all parameters", function()
+    vim.bo.filetype = "markdown"
+
+    local template_func = function(context)
+      return "File: "
+        .. context.file_name
+        .. ", Path: "
+        .. context.file_path
+        .. ", Cursor: "
+        .. context.cursor
+        .. ", Label: "
+        .. context.label
+        .. ", No Ext: "
+        .. context.file_name_no_ext
+    end
+
+    config.setup({ markdown = { template = template_func } })
+
+    local expected = "File: $FILE_NAME, Path: $FILE_PATH, Cursor: $CURSOR, Label: $LABEL, No Ext: $FILE_NAME_NO_EXT"
+    assert.equals(expected, config.get_option("template"))
+  end)
 end)

--- a/tests/markup_spec.lua
+++ b/tests/markup_spec.lua
@@ -89,5 +89,29 @@ describe("markup", function()
 
       assert.is_true(success)
     end)
+
+    it("inserts correct markup into a file when using template args", function()
+      config.setup({
+        default = {
+          template = function(context)
+            return context.cursor
+              .. " "
+              .. context.file_path
+              .. " "
+              .. context.file_name
+              .. " "
+              .. context.file_name_no_ext
+              .. " "
+              .. context.label
+          end,
+        },
+      })
+
+      local success = markup.insert_markup("/path/to/file.png")
+      local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+
+      assert.equal(" /path/to/file.png file.png file file", lines[2])
+      assert.is_true(success)
+    end)
   end)
 end)

--- a/vimdoc.md
+++ b/vimdoc.md
@@ -198,6 +198,14 @@ Templates in the plugin use placeholders that are dynamically replaced with the 
 | `$LABEL`            | Figure label, generated from the file name, converted to lower-case and with spaces replaced by dashes. | `the-image` (from `the image.png`) |
 | `$CURSOR`           | Indicates where the cursor will be placed after insertion if `use_cursor_in_template` is true.          |                                    |
 
+Templates can also be defined using functions with the above placeholders available as function parameters:
+
+```lua
+template = function(placeholders)
+  return "![" .. placeholders.cursor .. "](" .. placeholders.file_path .. ")"
+end
+```
+
 ## Drag and drop
 
 The drag and drop feature enables users to drag images from the web browser or file explorer into the terminal to automatically embed them, in **normal mode**. For this to work correctly, the following is required by the terminal emulator:

--- a/vimdoc.md
+++ b/vimdoc.md
@@ -201,8 +201,8 @@ Templates in the plugin use placeholders that are dynamically replaced with the 
 Templates can also be defined using functions with the above placeholders available as function parameters:
 
 ```lua
-template = function(placeholders)
-  return "![" .. placeholders.cursor .. "](" .. placeholders.file_path .. ")"
+template = function(context)
+  return "![" .. context.cursor .. "](" .. context.file_path .. ")"
 end
 ```
 


### PR DESCRIPTION
## Related issue

Closes #26.

## Summary of changes

Passes the following args to the template function: 

```lua
local template_args = {
  file_path = file_path,
  file_name = file_name,
  file_name_no_ext = file_name_no_ext,
  cursor = "$CURSOR",
  label = label,
}
```

- Added a test which uses all of the placeholders.
- Updated readme and vimdoc 
