### PR TITLE
feat: project specific config files

### DIFF
--- a/lua/img-clip/config.lua
+++ b/lua/img-clip/config.lua
@@ -129,8 +129,12 @@ end
 local function get_config()
   -- use cached config if available
   local dir_path = vim.fn.expand("%:p:h")
-  if M.configs[dir_path] then
+  if M.configs[dir_path] and M.configs[dir_path] ~= {} then
     return M.configs[dir_path]
+
+  -- no config file found, use default config
+  elseif M.configs[dir_path] == {} then
+    return M.opts
   end
 
   -- find config file in the current directory or any parent directory
@@ -143,9 +147,10 @@ local function get_config()
       config_file_options = sort_config(config_file_options)
       M.configs[dir_path] = config_file_options
       return config_file_options
+    else
+      M.configs[dir_path] = {}
+      print("Error loading config file: " .. output)
     end
-
-    print("Error loading config file: " .. output)
   end
 
   -- use default config if no config file is found

--- a/lua/img-clip/config.lua
+++ b/lua/img-clip/config.lua
@@ -100,6 +100,8 @@ defaults.filetypes.plaintex = defaults.filetypes.tex
 defaults.filetypes.rmd = defaults.filetypes.markdown
 defaults.filetypes.md = defaults.filetypes.markdown
 
+---@param opts table
+---@return table
 local function sort_config(opts)
   local function sort_keys(tbl)
     local sorted_keys = {}
@@ -121,6 +123,9 @@ local function sort_config(opts)
   return opts
 end
 
+---Gets the config
+---Can be either the default config or the config from the config file
+---@return table
 local function get_config()
   -- use cached config if available
   local dir_path = vim.fn.expand("%:p:h")
@@ -179,7 +184,7 @@ end
 
 ---Gets the option from the custom table
 ---@param key string
----@param args table
+---@param args? table
 ---@return string | nil
 local function get_custom_opt(key, opts, args)
   if opts["custom"] == nil then
@@ -195,7 +200,7 @@ end
 
 ---Gets the option from the files table
 ---@param key string
----@param args table
+---@param args? table
 ---@return string | nil
 local function get_file_opt(key, opts, args, file)
   if opts["files"] == nil then
@@ -217,7 +222,7 @@ end
 
 ---Gets the option from the dirs table
 ---@param key string
----@param args table
+---@param args? table
 ---@return string | nil
 local function get_dir_opt(key, opts, args, dir)
   if opts["dirs"] == nil then
@@ -260,6 +265,8 @@ end
 
 ---@param key string: The key, may be nested (e.g. "default.debug")
 ---@param api_opts? table: The opts passed to pasteImage function
+---@param args? table: Args that should be passed to the option function
+---@param opts? table: The opts table to use instead of the config
 ---@return string | nil
 M.get_opt = function(key, api_opts, args, opts)
   if api_opts then
@@ -270,6 +277,7 @@ M.get_opt = function(key, api_opts, args, opts)
   end
 
   -- if options are passed explicitly, use those instead of the config
+  -- otherwise use the config (either from file or neovim config)
   opts = opts or get_config()
 
   local val = get_custom_opt(key, opts, args)

--- a/lua/img-clip/config.lua
+++ b/lua/img-clip/config.lua
@@ -262,9 +262,11 @@ end
 ---@param api_opts? table: The opts passed to pasteImage function
 ---@return string | nil
 M.get_opt = function(key, api_opts, args, opts)
-  if api_opts and api_opts[key] ~= nil then
-    local val = api_opts[key]
-    return get_val(val, args)
+  if api_opts then
+    local val = M.get_opt(key, nil, args, api_opts)
+    if val then
+      return get_val(val, args)
+    end
   end
 
   -- if options are passed explicitly, use those instead of the config

--- a/lua/img-clip/config.lua
+++ b/lua/img-clip/config.lua
@@ -136,7 +136,6 @@ local function get_config()
     if success then
       local config_file_options = vim.tbl_deep_extend("force", {}, M.opts, output)
       config_file_options = sort_config(config_file_options)
-      -- return config_file_options
       M.configs[dir_path] = config_file_options
       return config_file_options
     end

--- a/lua/img-clip/config.lua
+++ b/lua/img-clip/config.lua
@@ -121,6 +121,20 @@ local function sort_config(opts)
 end
 
 local function get_config()
+  -- use cached config if available
+  local dir_path = vim.fn.expand("%:p:h")
+  if M.configs[dir_path] then
+    return M.configs[dir_path]
+  end
+
+  --- find config file in current directory or any parent directory
+  local config_file = vim.fn.findfile(".img-clip.lua", ".;")
+  if config_file ~= "" then
+    M.configs[dir_path] = dofile(config_file)
+    return M.configs[dir_path]
+  end
+
+  -- if no config file is found, use the default config
   return M.configs["config_opts"]
 end
 
@@ -244,6 +258,7 @@ M.get_opt = function(key, api_opts, args, opts)
     return get_val(val, args)
   end
 
+  -- if options are passed explicitly, use those instead of the config
   opts = opts or get_config()
 
   local val = get_custom_opt(key, opts, args)

--- a/tests/clipboard_spec.lua
+++ b/tests/clipboard_spec.lua
@@ -1,7 +1,13 @@
 local clipboard = require("img-clip.clipboard")
+local config = require("img-clip.config")
 local util = require("img-clip.util")
 
 describe("clipboard", function()
+  before_each(function()
+    config.setup({})
+    config.configs = {}
+  end)
+
   describe("x11", function()
     before_each(function()
       os.getenv = function(env)

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -4,6 +4,7 @@ describe("config", function()
   before_each(function()
     vim.bo.filetype = ""
     config.setup({})
+    config.configs = {}
   end)
 
   it("should have default values for all configuration options", function()

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -69,4 +69,13 @@ describe("config", function()
       })
     )
   end)
+
+  it("should allow nested API options", function()
+    vim.bo.filetype = "markdown"
+
+    assert.equals(
+      "markdown-template",
+      config.get_opt("template", { filetypes = { markdown = { template = "markdown-template" } } })
+    )
+  end)
 end)

--- a/tests/drag_and_drop_spec.lua
+++ b/tests/drag_and_drop_spec.lua
@@ -3,10 +3,13 @@ local config = require("img-clip.config")
 local util = require("img-clip.util")
 
 describe("drag and drop", function()
+  before_each(function()
+    config.setup({})
+    config.configs = {}
+  end)
+
   describe("handle_paste", function()
     before_each(function()
-      config.setup({}) -- use default config
-
       vim.fn.mode = function()
         return "n"
       end

--- a/tests/fs_spec.lua
+++ b/tests/fs_spec.lua
@@ -3,13 +3,16 @@ local util = require("img-clip.util")
 local fs = require("img-clip.fs")
 
 describe("fs", function()
+  before_each(function()
+    config.setup({})
+    config.configs = {}
+  end)
+
   describe("get_file_path", function()
     before_each(function()
       util.input = function() -- mock user input
         return ""
       end
-
-      config.setup({}) -- use default config values
     end)
 
     it("uses default directory and filename if no options or user inputs are provided", function()

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -7,6 +7,11 @@ local spy = require("luassert.spy")
 local config = require("img-clip.config")
 
 describe("img-clip.init", function()
+  before_each(function()
+    config.setup({})
+    config.configs = {}
+  end)
+
   describe("pasteImage", function()
     before_each(function()
       init.clip_cmd = nil
@@ -34,8 +39,6 @@ describe("img-clip.init", function()
       markup.insert_markup = function()
         return true
       end
-
-      config.setup({})
 
       spy.on(util, "warn")
       spy.on(util, "error")

--- a/tests/markup_spec.lua
+++ b/tests/markup_spec.lua
@@ -2,6 +2,11 @@ local markup = require("img-clip.markup")
 local config = require("img-clip.config")
 
 describe("markup", function()
+  before_each(function()
+    config.setup({})
+    config.configs = {}
+  end)
+
   describe("url_encode", function()
     it("encodes spaces", function()
       local result = markup.url_encode("hello world.png")

--- a/tests/util_spec.lua
+++ b/tests/util_spec.lua
@@ -2,6 +2,11 @@ local util = require("img-clip.util")
 local config = require("img-clip.config")
 
 describe("util", function()
+  before_each(function()
+    config.setup({})
+    config.configs = {}
+  end)
+
   describe("execute", function()
     before_each(function()
       vim.o.shell = "cmd.exe"
@@ -12,8 +17,6 @@ describe("util", function()
       vim.fn.has = function()
         return 0
       end
-
-      config.setup()
     end)
 
     it("should return output and exit code", function()

--- a/tests/util_spec.lua
+++ b/tests/util_spec.lua
@@ -1,4 +1,5 @@
 local util = require("img-clip.util")
+local config = require("img-clip.config")
 
 describe("util", function()
   describe("execute", function()
@@ -11,6 +12,8 @@ describe("util", function()
       vim.fn.has = function()
         return 0
       end
+
+      config.setup()
     end)
 
     it("should return output and exit code", function()


### PR DESCRIPTION
## Related issue

Closes #31.

## Summary of changes

Added a `get_config` method which gets the correct configuration:
- Search through the `cwd` (of the currently opened file) and its parent directories to find the nearest `.img-clip.lua` file
- If file is found, merge its contents with the user configuration 
- Otherwise, use the default user configuration 

Configurations are cached in the `M.configs` variable so the overhead is minimized. 

Also added the ability to pass nested configuration options through the API. 