### PR TITLE
fix: add base64 length warning

### DIFF
--- a/lua/img-clip/paste.lua
+++ b/lua/img-clip/paste.lua
@@ -182,7 +182,10 @@ M.embed_image_as_base64 = function(file_path, opts)
   end
 
   -- check if base64 string is too long (max_base64_size is in KB)
-  if string.len(base64) > config.get_opt("max_base64_size", opts) * 1024 then
+  local base64_size_kb = (string.len(base64) * 6) / (8 * 1024)
+  local max_size_kb = config.get_opt("max_base64_size", opts)
+  if base64_size_kb > max_size_kb then
+    util.warn("Base64 string is too large (" .. base64_size_kb .. " KB). Max allowed size is " .. max_size_kb .. " KB.")
     return false
   end
 

--- a/lua/img-clip/paste.lua
+++ b/lua/img-clip/paste.lua
@@ -182,7 +182,7 @@ M.embed_image_as_base64 = function(file_path, opts)
   end
 
   -- check if base64 string is too long (max_base64_size is in KB)
-  local base64_size_kb = (string.len(base64) * 6) / (8 * 1024)
+  local base64_size_kb = math.floor((string.len(base64) * 6) / (8 * 1024))
   local max_size_kb = config.get_opt("max_base64_size", opts)
   if base64_size_kb > max_size_kb then
     util.warn("Base64 string is too large (" .. base64_size_kb .. " KB). Max allowed size is " .. max_size_kb .. " KB.")


### PR DESCRIPTION
## Related issue

Closes #47.

## Summary of changes

- Properly calculate the base64 size in KB
- Add a warning message when Base64 size exceeds the `max_base64_size` set in the config 