### PR TITLE
fix: disable health message on startup

### DIFF
--- a/lua/img-clip/init.lua
+++ b/lua/img-clip/init.lua
@@ -1,17 +1,11 @@
-local clipboard = require("img-clip.clipboard")
 local config = require("img-clip.config")
 local paste = require("img-clip.paste")
-local util = require("img-clip.util")
 
 local M = {}
 
 ---@param opts? table
 M.setup = function(opts)
   config.setup(opts)
-
-  if not clipboard.get_clip_cmd() then
-    util.error("Could not get clipboard command. See :checkhealth img-clip.")
-  end
 end
 
 ---@param opts? table

--- a/lua/img-clip/paste.lua
+++ b/lua/img-clip/paste.lua
@@ -24,6 +24,12 @@ M.paste_image = function(opts, input)
     return false
   end
 
+  -- ensure clipboard command is valid
+  if not clipboard.get_clip_cmd() then
+    util.error("Could not get clipboard command. See :checkhealth img-clip.")
+    return false
+  end
+
   -- if no input is provided, check clipboard content
   if clipboard.content_is_image() then
     return M.paste_image_from_clipboard(opts)

--- a/tests/paste_spec.lua
+++ b/tests/paste_spec.lua
@@ -1,6 +1,7 @@
 local clipboard = require("img-clip.clipboard")
 local paste = require("img-clip.paste")
 local config = require("img-clip.config")
+local util = require("img-clip.util")
 local spy = require("luassert.spy")
 
 describe("paste", function()
@@ -8,6 +9,15 @@ describe("paste", function()
     config.setup({})
     config.get_config = function()
       return config.opts
+    end
+    os.getenv = function(env)
+      return env == "DISPLAY"
+    end
+    util.has = function()
+      return false
+    end
+    util.executable = function(cmd)
+      return cmd == "xclip"
     end
   end)
 


### PR DESCRIPTION
## Related issue

Closes #49.

## Summary of changes

- Don't show health message on startup 
- Only show health message when an image paste is invoked

