### PR TITLE
refactor: simplify markup logic

### DIFF
--- a/lua/img-clip/paste.lua
+++ b/lua/img-clip/paste.lua
@@ -87,7 +87,7 @@ M.paste_image_from_url = function(url)
     util.warn("Output: " .. output, true)
   end
 
-  if not markup.insert_markup(file_path) then
+  if not markup.insert_markup(file_path, true) then
     util.error("Could not insert markup code.")
     return false
   end
@@ -104,7 +104,7 @@ M.paste_image_from_path = function(src_path)
   end
 
   if not config.get_opt("drag_and_drop.copy_images") then
-    if not markup.insert_markup(src_path) then
+    if not markup.insert_markup(src_path, true) then
       util.error("Could not insert markup code.")
       return false
     end
@@ -135,7 +135,7 @@ M.paste_image_from_path = function(src_path)
     util.warn("Output: " .. output, true)
   end
 
-  if not markup.insert_markup(file_path) then
+  if not markup.insert_markup(file_path, true) then
     util.error("Could not insert markup code.")
     return false
   end
@@ -175,7 +175,7 @@ M.paste_image_from_clipboard = function()
     end
   end
 
-  if not markup.insert_markup(file_path) then
+  if not markup.insert_markup(file_path, true) then
     util.error("Could not insert markup code.")
     return false
   end
@@ -213,7 +213,7 @@ M.embed_image_as_base64 = function(file_path)
   end
 
   local prefix = M.get_base64_prefix()
-  if not markup.insert_base64_markup(prefix .. base64) then
+  if not markup.insert_markup(prefix .. base64) then
     util.error("Could not insert markup code.")
     return false
   end

--- a/tests/markup_spec.lua
+++ b/tests/markup_spec.lua
@@ -64,7 +64,7 @@ describe("markup", function()
     end)
 
     it("inserts markup into a file", function()
-      local success = markup.insert_markup("/path/to/file.png")
+      local success = markup.insert_markup("/path/to/file.png", true)
       local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
 
       assert.equal("/path/to/file.png", lines[2])
@@ -74,7 +74,7 @@ describe("markup", function()
     it("inserts markup into a markdown file", function()
       vim.bo.filetype = "markdown"
 
-      local success = markup.insert_markup("/path/to/file.png")
+      local success = markup.insert_markup("/path/to/file.png", true)
       local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
 
       assert.equal("![](/path/to/file.png)", lines[2])
@@ -84,7 +84,7 @@ describe("markup", function()
     it("inserts markup into a LaTeX file", function()
       vim.bo.filetype = "tex"
 
-      local success = markup.insert_markup("/path/to/example file.png")
+      local success = markup.insert_markup("/path/to/example file.png", true)
       local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
 
       assert.equal("\\begin{figure}[h]", lines[2])
@@ -114,7 +114,7 @@ describe("markup", function()
         },
       })
 
-      local success = markup.insert_markup("/path/to/file.png")
+      local success = markup.insert_markup("/path/to/file.png", true)
       local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
 
       assert.equal(" /path/to/file.png file.png file file", lines[2])


### PR DESCRIPTION
## Summary of changes

- Refactored the markup logic such that the `insert_markup` method now accepts an optional `is_file_path` argument
- Created a `get_template` function for getting the correct template, differentiating between the processing that needs to be done for file paths and other inputs like Base64 or URLs.
