### PR TITLE
fix: escape special characters in `process_cmd`

### DIFF
--- a/lua/img-clip/clipboard.lua
+++ b/lua/img-clip/clipboard.lua
@@ -79,19 +79,20 @@ M.save_image = function(file_path)
 
   -- Linux (X11)
   if cmd == "xclip" then
-    local command = string.format('xclip -selection clipboard -o -t image/png %s> "%s"', process_cmd, file_path)
+    local command =
+      string.format('xclip -selection clipboard -o -t image/png %s> "%s"', process_cmd:gsub("%%", "%%%%"), file_path)
     local _, exit_code = util.execute(command)
     return exit_code == 0
 
   -- Linux (Wayland)
   elseif cmd == "wl-paste" then
-    local command = string.format('wl-paste --type image/png %s> "%s"', process_cmd, file_path)
+    local command = string.format('wl-paste --type image/png %s> "%s"', process_cmd:gsub("%%", "%%%%"), file_path)
     local _, exit_code = util.execute(command)
     return exit_code == 0
 
   -- MacOS (pngpaste) which is faster than osascript
   elseif cmd == "pngpaste" then
-    local command = string.format('pngpaste - %s> "%s"', process_cmd, file_path)
+    local command = string.format('pngpaste - %s> "%s"', process_cmd:gsub("%%", "%%%%"), file_path)
     local _, exit_code = util.execute(command)
     return exit_code == 0
 
@@ -103,7 +104,7 @@ M.save_image = function(file_path)
         .. [[-e 'close access theFile' -e 'do shell script "cat %s %s> %s"']],
       file_path,
       file_path,
-      process_cmd,
+      process_cmd:gsub("%%", "%%%%"),
       file_path
     )
     local _, exit_code = util.execute(command)

--- a/lua/img-clip/fs.lua
+++ b/lua/img-clip/fs.lua
@@ -177,7 +177,7 @@ M.process_image = function(file_path, opts)
 
   -- process image
   local output, exit_code =
-    util.execute(string.format("cat '%s' | %s > '%s'", file_path, process_cmd, tmp_file_path), true)
+    util.execute(string.format("cat '%s' | %s > '%s'", file_path, process_cmd:gsub("%%", "%%%%"), tmp_file_path), true)
   if exit_code == 0 then
     M.copy_file(tmp_file_path, file_path)
   end
@@ -207,7 +207,7 @@ M.get_base64_encoded_image = function(file_path)
 
   -- Linux/MacOS
   else
-    local command = string.format("cat '%s' " .. process_cmd .. "| base64 | tr -d '\n'", file_path)
+    local command = string.format("cat '%s' " .. process_cmd:gsub("%%", "%%%%") .. "| base64 | tr -d '\n'", file_path)
     local output, exit_code = util.execute(command)
     if exit_code == 0 then
       return output


### PR DESCRIPTION
## Summary of changes

- Properly escapes special characters in the `process_cmd` before executing it. This allows commands like `convert - -resize 10% -` to execute correctly. 
