### PR TITLE
refactor: drag and drop options

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,12 +93,12 @@ The plugin comes with the following defaults:
     embed_image_as_base64 = false, -- paste image as base64 string instead of saving to file
     max_base64_size = 10, -- max size of base64 string in KB
     template = "$FILE_PATH", -- default template
+    copy_images = false, -- copy images instead of using the original file
+    download_images = true, -- download images and save them to dir_path instead of using the URL
 
     drag_and_drop = {
       enabled = true, -- enable drag and drop mode
       insert_mode = false, -- enable drag and drop in insert mode
-      copy_images = false, -- copy images instead of using the original file
-      download_images = true, -- download images and save them to dir_path instead of using the URL
     },
   },
 

--- a/README.md
+++ b/README.md
@@ -111,10 +111,7 @@ The plugin comes with the following defaults:
     markdown = {
       url_encode_path = true,
       template = "![$CURSOR]($FILE_PATH)",
-
-      drag_and_drop = {
-        download_images = false,
-      },
+      download_images = false,
     },
 
     html = {

--- a/lua/img-clip/config.lua
+++ b/lua/img-clip/config.lua
@@ -30,8 +30,6 @@ local defaults = {
     drag_and_drop = {
       enabled = true, -- enable drag and drop mode
       insert_mode = false, -- enable drag and drop in insert mode
-      copy_images = false, -- copy images instead of using the original file
-      download_images = true, -- download images and save them to dir_path instead of using the URL
     },
   },
 
@@ -44,10 +42,7 @@ local defaults = {
     markdown = {
       url_encode_path = true,
       template = "![$CURSOR]($FILE_PATH)",
-
-      drag_and_drop = {
-        download_images = false,
-      },
+      download_images = false,
     },
 
     html = {

--- a/lua/img-clip/config.lua
+++ b/lua/img-clip/config.lua
@@ -1,5 +1,6 @@
 local M = {}
 
+M.drag_and_drop = false
 M.config_file = "Default"
 M.sorted_files = {}
 M.sorted_dirs = {}
@@ -23,6 +24,8 @@ local defaults = {
     embed_image_as_base64 = false, -- paste image as base64 string instead of saving to file
     max_base64_size = 10, -- max size of base64 string in KB
     template = "$FILE_PATH", -- default template
+    copy_images = false, -- copy images instead of using the original file
+    download_images = true, -- download images and save them to dir_path instead of using the URL
 
     drag_and_drop = {
       enabled = true, -- enable drag and drop mode
@@ -290,6 +293,15 @@ M.get_opt = function(key, args, opts)
       return val
     end
     return M.get_opt(key, args, M.get_config())
+  end
+
+  -- if we're in drag and drop mode, try to get drag and drop options
+  -- and then fall back to the regular options if they're not found
+  if M.drag_and_drop and not key:find("drag_and_drop") then
+    local val = M.get_opt("drag_and_drop." .. key, args, M.opts)
+    if val ~= nil then
+      return val
+    end
   end
 
   local val = get_custom_opt(key, opts, args)

--- a/lua/img-clip/paste.lua
+++ b/lua/img-clip/paste.lua
@@ -48,7 +48,7 @@ end
 
 ---@param url string
 M.paste_image_from_url = function(url)
-  if not config.get_opt("drag_and_drop.download_images") then
+  if not config.get_opt("download_images") then
     if not markup.insert_markup(url) then
       util.error("Could not insert markup code.")
       return false
@@ -103,7 +103,7 @@ M.paste_image_from_path = function(src_path)
     end
   end
 
-  if not config.get_opt("drag_and_drop.copy_images") then
+  if not config.get_opt("copy_images") then
     if not markup.insert_markup(src_path, true) then
       util.error("Could not insert markup code.")
       return false

--- a/plugin/img-clip.lua
+++ b/plugin/img-clip.lua
@@ -72,9 +72,15 @@ vim.paste = (function(original)
     end
 
     util.verbose = false
-    if not plugin.pasteImage({}, line) then
+    config.drag_and_drop = true
+
+    local ok = plugin.pasteImage({}, line)
+
+    config.drag_and_drop = false
+    util.verbose = true
+
+    if not ok then
       debug.log("Did not handle paste, calling original vim.paste")
-      util.verbose = true
       return original(lines, phase) -- if we did not handle the paste, call the original vim.paste function
     end
   end

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -26,13 +26,10 @@ describe("config", function()
 
     assert.is_true(config.get_opt("drag_and_drop.enabled"))
     assert.is_false(config.get_opt("drag_and_drop.insert_mode"))
-    assert.is_false(config.get_opt("drag_and_drop.copy_images"))
-    assert.is_true(config.get_opt("drag_and_drop.download_images"))
 
     vim.bo.filetype = "markdown"
     assert.is_true(config.get_opt("url_encode_path"))
     assert.equals("![$CURSOR]($FILE_PATH)", config.get_opt("template"))
-    assert.is_false(config.get_opt("drag_and_drop.download_images"))
   end)
 
   it("should allow overriding default values", function()

--- a/vimdoc.md
+++ b/vimdoc.md
@@ -102,10 +102,7 @@ The plugin comes with the following defaults:
     markdown = {
       url_encode_path = true,
       template = "![$CURSOR]($FILE_PATH)",
-
-      drag_and_drop = {
-        download_images = false,
-      },
+      download_images = false,
     },
 
     html = {

--- a/vimdoc.md
+++ b/vimdoc.md
@@ -84,12 +84,12 @@ The plugin comes with the following defaults:
     embed_image_as_base64 = false, -- paste image as base64 string instead of saving to file
     max_base64_size = 10, -- max size of base64 string in KB
     template = "$FILE_PATH", -- default template
+    copy_images = false, -- copy images instead of using the original file
+    download_images = true, -- download images and save them to dir_path instead of using the URL
 
     drag_and_drop = {
       enabled = true, -- enable drag and drop mode
       insert_mode = false, -- enable drag and drop in insert mode
-      copy_images = false, -- copy images instead of using the original file
-      download_images = true, -- download images and save them to dir_path instead of using the URL
     },
   },
 


### PR DESCRIPTION
## Summary of changes

- Added a `config.drag_and_drop` option which allows the plugin to know if a paste was invoked as a drag and drop action 
- When getting options using the `get_opt` function, the code will now first check if we're in drag and drop mode. If we are, we prepend "drag_and_drop." to the key and recursively check if we can find it. If not, we use the default options. This allows the user to override any option under the `drag_and_drop` options
- Moved `copy_images` and `download_images` outside of drag and drop, as these are also relevant as "normal" options now that the API  is more powerfull
