### PR TITLE
fix: only add file extension if its missing

### DIFF
--- a/lua/img-clip/fs.lua
+++ b/lua/img-clip/fs.lua
@@ -117,8 +117,10 @@ M.get_file_path = function(ext)
     file_path = dir_path .. config_file_name
   end
 
-  -- add file ext
-  file_path = M.add_file_ext(file_path, ext)
+  -- add file ext if missing
+  if vim.fn.fnamemodify(file_path, ":e") == "" then
+    file_path = M.add_file_ext(file_path, ext)
+  end
   return file_path
 end
 

--- a/lua/img-clip/paste.lua
+++ b/lua/img-clip/paste.lua
@@ -48,6 +48,7 @@ end
 
 ---@param url string
 M.paste_image_from_url = function(url)
+  -- if we are not downloading images, then just insert the url
   if not config.get_opt("download_images") then
     if not markup.insert_markup(url) then
       util.error("Could not insert markup code.")
@@ -103,6 +104,7 @@ M.paste_image_from_path = function(src_path)
     end
   end
 
+  -- if we are not copying images, then just insert the original path
   if not config.get_opt("copy_images") then
     if not markup.insert_markup(src_path, true) then
       util.error("Could not insert markup code.")


### PR DESCRIPTION
## Summary of changes

- Checks if the user has added a file extension to the file path. If they have, don't add the .png file extension
