### PR TITLE
fix: use sh -c to execute commands

### DIFF
--- a/lua/img-clip/util.lua
+++ b/lua/img-clip/util.lua
@@ -6,7 +6,7 @@ local M = {}
 M.verbose = true
 
 ---@param input_cmd string
----@param execute_directly boolean
+---@param execute_directly? boolean
 ---@return string | nil output
 ---@return number exit_code
 M.execute = function(input_cmd, execute_directly)
@@ -33,7 +33,7 @@ M.execute = function(input_cmd, execute_directly)
 
   -- otherwise (linux, macos), execute the command directly
   else
-    cmd = input_cmd
+    cmd = "sh -c " .. vim.fn.shellescape(input_cmd)
   end
 
   local output = vim.fn.system(cmd)

--- a/tests/util_spec.lua
+++ b/tests/util_spec.lua
@@ -25,7 +25,7 @@ describe("util", function()
       local command = "command"
       local output, exit_code = util.execute(command)
 
-      assert.equal(output, command)
+      assert.equal(output, "sh -c 'command'")
       assert.equal(exit_code, 0)
     end)
 


### PR DESCRIPTION
## Related issue

Closes #64. User has likely set Fish as their default shell in Neovim.

## Summary of changes

- Use `sh -c` to ensure the shell used for execution is POSIX compliant
