### PR TITLE
Prompt for caption and create filename from it

### DIFF
--- a/lua/img-clip/config.lua
+++ b/lua/img-clip/config.lua
@@ -27,6 +27,7 @@ local defaults = {
     -- prompt options
     prompt_for_file_name = true, ---@type boolean
     show_dir_path_in_prompt = false, ---@type boolean
+    prompt_for_caption = false, ---@type boolean
 
     -- base64 options
     max_base64_size = 10, ---@type number

--- a/lua/img-clip/markup.lua
+++ b/lua/img-clip/markup.lua
@@ -60,13 +60,14 @@ end
 ---@param input string
 ---@param is_file_path? boolean
 ---@return string | nil
-function M.get_template(input, is_file_path)
+function M.get_template(input, is_file_path, caption)
   local template_args = {
     file_path = "",
     file_name = "",
     file_name_no_ext = "",
     cursor = "$CURSOR",
     label = "",
+    caption = "",
   }
 
   if is_file_path then
@@ -74,6 +75,7 @@ function M.get_template(input, is_file_path)
     template_args.file_name = vim.fn.fnamemodify(input, ":t")
     template_args.file_name_no_ext = vim.fn.fnamemodify(input, ":t:r")
     template_args.label = template_args.file_name_no_ext:gsub("%s+", "-"):lower()
+    template_args.caption = caption
 
     -- see issue #21
     local current_dir_path = vim.fn.expand("%:p:h")
@@ -94,6 +96,7 @@ function M.get_template(input, is_file_path)
     end
   else
     template_args.file_path = input
+    template_args.caption = caption
   end
 
   local template = config.get_opt("template", template_args)
@@ -105,6 +108,7 @@ function M.get_template(input, is_file_path)
   template = template:gsub("$FILE_NAME", template_args.file_name)
   template = template:gsub("$FILE_PATH", template_args.file_path)
   template = template:gsub("$LABEL", template_args.label)
+  template = template:gsub("$CAPTION", template_args.caption)
 
   if not config.get_opt("use_cursor_in_template") then
     template = template:gsub("$CURSOR", "")
@@ -116,8 +120,8 @@ end
 ---@param input string
 ---@param is_file_path? boolean
 ---@return boolean
-function M.insert_markup(input, is_file_path)
-  local template = M.get_template(input, is_file_path)
+function M.insert_markup(input, is_file_path, caption)
+  local template = M.get_template(input, is_file_path, caption)
   if not template then
     return false
   end

--- a/lua/img-clip/paste.lua
+++ b/lua/img-clip/paste.lua
@@ -59,7 +59,7 @@ M.paste_image_from_url = function(url)
   end
 
   local extension = config.get_opt("extension")
-  local file_path = fs.get_file_path(extension)
+  local file_path, caption = fs.get_file_path_and_caption(extension)
   if not file_path then
     util.error("Could not determine file path.")
     return false
@@ -89,7 +89,7 @@ M.paste_image_from_url = function(url)
     util.warn("Output: " .. output, true)
   end
 
-  if not markup.insert_markup(file_path, true) then
+  if not markup.insert_markup(file_path, true, caption) then
     util.error("Could not insert markup code.")
     return false
   end
@@ -116,7 +116,7 @@ M.paste_image_from_path = function(src_path)
   end
 
   local extension = config.get_opt("extension")
-  local file_path = fs.get_file_path(extension)
+  local file_path, caption = fs.get_file_path_and_caption(extension)
   if not file_path then
     util.error("Could not determine file path.")
     return false
@@ -139,7 +139,7 @@ M.paste_image_from_path = function(src_path)
     util.warn("Output: " .. output, true)
   end
 
-  if not markup.insert_markup(file_path, true) then
+  if not markup.insert_markup(file_path, true, caption) then
     util.error("Could not insert markup code.")
     return false
   end
@@ -155,7 +155,7 @@ M.paste_image_from_clipboard = function()
   end
 
   local extension = config.get_opt("extension")
-  local file_path = fs.get_file_path(extension)
+  local file_path, caption = fs.get_file_path_and_caption(extension)
   if not file_path then
     util.error("Could not determine file path.")
     return false
@@ -180,7 +180,7 @@ M.paste_image_from_clipboard = function()
     end
   end
 
-  if not markup.insert_markup(file_path, true) then
+  if not markup.insert_markup(file_path, true, caption) then
     util.error("Could not insert markup code.")
     return false
   end


### PR DESCRIPTION
## Related issue

Can be a possible solution for #76 

## Summary of changes

New option `prompt_for_caption` shows a prompt, creates a filename from it and replaces `$CAPTION` in template.
If `prompt_for_file_name` is also given, the suggested filename is already available in prompt.

This works fine for me:

```lua
      require("img-clip").setup({
        default = {
          relative_to_current_file = true,
          prompt_for_caption = true,
          prompt_for_file_name = true,
          show_dir_path_in_prompt = true,
        },
        filetypes = {
          markdown = {
            url_encode_path = true,
            template = "![$CAPTION]($FILE_PATH)$CURSOR",
            download_images = false,
          },
        },
      })
```

