### PR TITLE
Update config.lua

### DIFF
--- a/lua/img-clip/config.lua
+++ b/lua/img-clip/config.lua
@@ -202,8 +202,10 @@ end
 local function get_val(val, args)
   if val == nil then
     return nil
+  elseif type(val) == "function" then
+    return val(args or {})
   else
-    return type(val) == "function" and val(args or {}) or val
+    return val
   end
 end
 


### PR DESCRIPTION
Fix: always use the first custom setting

`type(val) == "function" and val(args or {}) or val` is always `true` when `val` is a function


