### PR TITLE
fix: relative path drag and drop

### DIFF
--- a/lua/img-clip/paste.lua
+++ b/lua/img-clip/paste.lua
@@ -107,6 +107,10 @@ M.paste_image_from_path = function(src_path)
 
   -- if we are not copying images, then just insert the original path
   if not config.get_opt("copy_images") then
+    if config.get_opt("relative_to_current_file") then
+      src_path = fs.relpath(src_path)
+    end
+
     if not markup.insert_markup(src_path, true) then
       util.error("Could not insert markup code.")
       return false

--- a/lua/img-clip/paste.lua
+++ b/lua/img-clip/paste.lua
@@ -107,7 +107,7 @@ M.paste_image_from_path = function(src_path)
 
   -- if we are not copying images, then just insert the original path
   if not config.get_opt("copy_images") then
-    if config.get_opt("relative_to_current_file") then
+    if not config.get_opt("use_absolute_path") then
       src_path = fs.relpath(src_path)
     end
 


### PR DESCRIPTION
## Related issue

Closes #80.

## Summary of changes

- Use relative path for drag and drop if `use_absolute_path` is `false`