### PR TITLE
stating `pngpaste` is required on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ https://github.com/HakonHarnes/img-clip.nvim/assets/89907156/ab4edc10-d296-4532-
 ## 🔧 Requirements
 
 - **Linux:** [xclip](https://github.com/astrand/xclip) (x11) or [wl-clipboard](https://github.com/bugaevc/wl-clipboard) (wayland)
-- **MacOS:** [pngpaste](https://github.com/jcsalterego/pngpaste) (optional, but recommended)
+- **MacOS:** [pngpaste](https://github.com/jcsalterego/pngpaste)
 - **Windows:** No additional requirements
 
 > [!IMPORTANT]


### PR DESCRIPTION
otherwise, you get empty .png files.