### PR TITLE
refactor: move setup function back to config.lua

### DIFF
--- a/lua/img-clip/config.lua
+++ b/lua/img-clip/config.lua
@@ -342,6 +342,8 @@ function M.setup(config_opts)
   M.opts = M.sort_config(M.opts)
 end
 
+M.setup()
+
 M.print_config = function()
   local config = M.get_config()
 

--- a/plugin/img-clip.lua
+++ b/plugin/img-clip.lua
@@ -3,8 +3,6 @@ local config = require("img-clip.config")
 local util = require("img-clip.util")
 local plugin = require("img-clip")
 
-plugin.setup()
-
 vim.api.nvim_create_user_command("PasteImage", function()
   plugin.pasteImage()
 end, {})


### PR DESCRIPTION
## Related issue

Closes #98 

## Summary of changes

- Moved `M.setup` call back to config file because it caused issues with vim-plug.
