### PR TITLE
Don't replace extension when copying a file

### DIFF
--- a/lua/img-clip/paste.lua
+++ b/lua/img-clip/paste.lua
@@ -119,7 +119,14 @@ M.paste_image_from_path = function(src_path)
     return true
   end
 
-  local extension = config.get_opt("extension")
+  local extension = ''
+  if vim.fn.fnamemodify(src_path, ":e") == "" then
+    print("File missing extension.  Adding png.")
+    extension = config.get_opt("extension")
+  else
+    extension = vim.fn.fnamemodify(src_path, ":e")
+  end
+
   local file_path = fs.get_file_path(extension)
   if not file_path then
     util.error("Could not determine file path.")

--- a/lua/img-clip/paste.lua
+++ b/lua/img-clip/paste.lua
@@ -119,12 +119,10 @@ M.paste_image_from_path = function(src_path)
     return true
   end
 
-  local extension = ''
-  if vim.fn.fnamemodify(src_path, ":e") == "" then
-    print("File missing extension.  Adding png.")
+  local extension = vim.fn.fnamemodify(src_path, ":e")
+  if extension == "" then
+    util.warn("File missing extension. Adding png.")
     extension = config.get_opt("extension")
-  else
-    extension = vim.fn.fnamemodify(src_path, ":e")
   end
 
   local file_path = fs.get_file_path(extension)


### PR DESCRIPTION
## Related issue

#106 

## Summary of changes

This will use the existing extension when copying a file if one exists.  
