### PR TITLE
feat: allow user to abort input with `ctrl+c`

### DIFF
--- a/lua/img-clip/fs.lua
+++ b/lua/img-clip/fs.lua
@@ -71,7 +71,7 @@ M.add_file_ext = function(str, ext)
 end
 
 ---@param ext string
----@return string
+---@return string | nil
 M.get_file_path = function(ext)
   local config_dir_path = config.get_opt("dir_path")
   local config_file_name = os.date(config.get_opt("file_name"))
@@ -94,7 +94,12 @@ M.get_file_path = function(ext)
         default = dir_path,
         completion = "file",
       })
-      if input_file_path and input_file_path ~= "" and input_file_path ~= dir_path then
+
+      if not input_file_path then
+        return nil
+      end
+
+      if input_file_path ~= "" and input_file_path ~= dir_path then
         file_path = input_file_path
       end
     else
@@ -102,6 +107,11 @@ M.get_file_path = function(ext)
         prompt = "File name: ",
         completion = "file",
       })
+
+      if not input_filename then
+        return nil
+      end
+
       if input_filename and input_filename ~= "" then
         file_path = dir_path .. input_filename
       end

--- a/lua/img-clip/paste.lua
+++ b/lua/img-clip/paste.lua
@@ -166,7 +166,6 @@ M.paste_image_from_clipboard = function()
   local extension = config.get_opt("extension")
   local file_path = fs.get_file_path(extension)
   if not file_path then
-    util.error("Could not determine file path.")
     return false
   end
 

--- a/lua/img-clip/util.lua
+++ b/lua/img-clip/util.lua
@@ -79,7 +79,7 @@ M.debug = function(msg)
   end
 end
 
----@param args string
+---@param args table
 M.input = function(args)
   local completed, output = pcall(function()
     return vim.fn.input(args)


### PR DESCRIPTION
## Related issue

Closes #109.

## Summary of changes

- The `input` function will not return `nil` if the user aborts the prompt using `ctrl + c` and execution will halt. 
