### PR TITLE
feat: prepend filename option

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ The plugin is highly configurable. Please refer to the default configuration bel
     dir_path = "assets", ---@type string | fun(): string
     extension = "png", ---@type string | fun(): string
     file_name = "%Y-%m-%d-%H-%M-%S", ---@type string | fun(): string
+    prepend_filename = false, ---@type boolean | fun(): boolean
     use_absolute_path = false, ---@type boolean | fun(): boolean
     relative_to_current_file = false, ---@type boolean | fun(): boolean
 

--- a/doc/img-clip.nvim.txt
+++ b/doc/img-clip.nvim.txt
@@ -115,6 +115,7 @@ below:
         dir_path = "assets", ---@type string | fun(): string
         extension = "png", ---@type string | fun(): string
         file_name = "%Y-%m-%d-%H-%M-%S", ---@type string | fun(): string
+        prepend_filename = false, ---@type boolean | fun(): boolean
         use_absolute_path = false, ---@type boolean | fun(): boolean
         relative_to_current_file = false, ---@type boolean | fun(): boolean
     

--- a/lua/img-clip/config.lua
+++ b/lua/img-clip/config.lua
@@ -14,6 +14,7 @@ local defaults = {
     dir_path = "assets", ---@type string
     extension = "png", ---@type string
     file_name = "%Y-%m-%d-%H-%M-%S", ---@type string
+    prepend_filename = false, ---@type boolean
     use_absolute_path = false, ---@type boolean
     relative_to_current_file = false, ---@type boolean
 

--- a/lua/img-clip/fs.lua
+++ b/lua/img-clip/fs.lua
@@ -123,6 +123,10 @@ M.get_file_path = function(ext)
     file_path = dir_path .. config_file_name
   end
 
+  if config.get_opt("prepend_filename") then
+    file_path = config_file_name .. "-" .. file_path
+  end
+
   -- add file ext if missing
   if vim.fn.fnamemodify(file_path, ":e") == "" then
     file_path = M.add_file_ext(file_path, ext)

--- a/vimdoc.md
+++ b/vimdoc.md
@@ -89,6 +89,7 @@ The plugin is highly configurable. Please refer to the default configuration bel
     dir_path = "assets", ---@type string | fun(): string
     extension = "png", ---@type string | fun(): string
     file_name = "%Y-%m-%d-%H-%M-%S", ---@type string | fun(): string
+    prepend_filename = false, ---@type boolean | fun(): boolean
     use_absolute_path = false, ---@type boolean | fun(): boolean
     relative_to_current_file = false, ---@type boolean | fun(): boolean
 


### PR DESCRIPTION
## Related issue

Ability to prepend file_name to the start of the file such that i can have multiple files named the same thing as long as they aren't created at the same time, e.g. "assets/20250514T121200-my-file.png" and "assets/20250514T121201-my-file.png". 

Currently those would be "assets/my-file.png" and "assets/my-file.png" which conflicts and only the second one is kept (should probably be a warning when overwriting a file that exists, but that's for another pr).

## Summary of changes

Add the option prepend_filename (bad name) and prepend the preexisting option file_name if true.