### PR TITLE
Add insert_at_cursor option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The plugin is highly configurable. Please refer to the default configuration bel
     relative_template_path = true, ---@type boolean | fun(): boolean
     use_cursor_in_template = true, ---@type boolean | fun(): boolean
     insert_mode_after_paste = true, ---@type boolean | fun(): boolean
+    insert_at_cursor = false, ---@type boolean
 
     -- prompt options
     prompt_for_file_name = true, ---@type boolean | fun(): boolean

--- a/lua/img-clip/config.lua
+++ b/lua/img-clip/config.lua
@@ -26,6 +26,7 @@ local defaults = {
     relative_template_path = true, ---@type boolean
     use_cursor_in_template = true, ---@type boolean
     insert_mode_after_paste = true, ---@type boolean
+    insert_at_cursor = false, ---@type boolean
 
     -- prompt options
     prompt_for_file_name = true, ---@type boolean

--- a/lua/img-clip/markup.lua
+++ b/lua/img-clip/markup.lua
@@ -45,14 +45,22 @@ function M.get_new_cursor_col(line, index, cur_col)
   local cursor_pos = line:find("$CURSOR")
   if cursor_pos then
     if config.get_opt("insert_at_cursor") and index == 1 then
-      return cur_col + cursor_pos
+      --db.log("col1")
+      --db.print_log()
+      return cur_col + cursor_pos - 1
     end
+      --db.log("col2")
+      --db.print_log()
     return cursor_pos - 1
   end
 
   if config.get_opt("insert_at_cursor") and index == 1 then
+      --db.log("col3")
+      --db.print_log()
     return cur_col + string.len(line)
   end
+      --db.log("col4")
+      --db.print_log()
 
   return string.len(line) - 1
 end
@@ -157,12 +165,19 @@ function M.insert_markup(input, is_file_path)
 
   -- enter insert mode if configured
   if config.get_opt("insert_mode_after_paste") and vim.api.nvim_get_mode().mode ~= "i" then
-    if new_col == string.len(line) - 1 or (index == 1 and config.get_opt("insert_at_cursor")) then
+    if new_col == string.len(line) - 1 then
+      --db.log("first")
+      vim.api.nvim_input("a")
+    elseif index == 1 and config.get_opt("insert_at_cursor") then
+      --db.log("second")
       vim.api.nvim_input("a")
     else
+      --db.log("third")
       vim.api.nvim_input("i")
     end
   end
+  --db.log(new_col)
+  --db.print_log()
 
   return true
 end

--- a/vimdoc.md
+++ b/vimdoc.md
@@ -101,6 +101,7 @@ The plugin is highly configurable. Please refer to the default configuration bel
     relative_template_path = true, ---@type boolean | fun(): boolean
     use_cursor_in_template = true, ---@type boolean | fun(): boolean
     insert_mode_after_paste = true, ---@type boolean | fun(): boolean
+    insert_at_cursor = false, ---@type boolean
 
     -- prompt options
     prompt_for_file_name = true, ---@type boolean | fun(): boolean


### PR DESCRIPTION
This simple PR adds the `insert_at_cursor` option. It's set to `false` by default and, if activated, it allows the user to have the result of the template expansion pasted at the current cursor position, instead of on a new line.

I've tested it extensively and it appears to work properly. I've also run the tests with `make test`.

Nevertheless, I didn't run `make luacheck` and `make stylua`.

Moreover, I haven't added the option to the user documentation, as I've seen that some of it may be automatically generate and I'm not sure what would be the best way to handle that.

This fixes one of the problems discusses in issue #126.